### PR TITLE
change http method for container right manage

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/container/ContainerRightsCommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/container/ContainerRightsCommandImpl.java
@@ -2,7 +2,7 @@ package org.javaswift.joss.command.impl.container;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpPost;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusFailCondition;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusMatch;
@@ -15,13 +15,13 @@ import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
 
-public class ContainerRightsCommandImpl extends AbstractContainerCommand<HttpPut, String[]> implements ContainerRightsCommand {
+public class ContainerRightsCommandImpl extends AbstractContainerCommand<HttpPost, String[]> implements ContainerRightsCommand {
 
     public ContainerRightsCommandImpl(Account account, HttpClient httpClient, Access access, Container container, boolean publicContainer) {
         super(account, httpClient, access, container);
         setHeader(new ContainerRights(publicContainer));
     }
-    
+
     public ContainerRightsCommandImpl(Account account, HttpClient httpClient, Access access, Container container, String writePermissions, String readPermissions) {
         super(account, httpClient, access, container);
         setHeader(new ContainerWritePermissions(writePermissions));
@@ -29,8 +29,8 @@ public class ContainerRightsCommandImpl extends AbstractContainerCommand<HttpPut
     }
 
     @Override
-    protected HttpPut createRequest(String url) {
-        return new HttpPut(url);
+    protected HttpPost createRequest(String url) {
+        return new HttpPost(url);
     }
 
     @Override


### PR DESCRIPTION
This PR fix incompatible with ceph swift realisation, and align with official swift specs.

http://docs.openstack.org/api/openstack-object-storage/1.0/content/storage_container_services.html
http://docs.openstack.org/api/openstack-object-storage/1.0/content/POST_updateContainerMeta_v1__account___container__storage_container_services.html
