### PR TITLE
Added delimiters to container list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ joss.iml
 target
 create-jar.sh
 src/main/java/nl/tweeenveertig/openstack/Main.java
+.DS_Store

--- a/src/main/java/org/javaswift/joss/client/core/AbstractContainer.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractContainer.java
@@ -57,6 +57,15 @@ public abstract class AbstractContainer extends AbstractObjectStoreEntity<Contai
                 .setLimit(pageSize);
         return commandFactory.createListObjectsCommand(getAccount(), this, listInstructions).call();
     }
+    
+    public Collection<StoredObject> list(String prefix, String delimeter, String marker, int pageSize) {
+        ListInstructions listInstructions = new ListInstructions()
+                .setPrefix(prefix)
+                .setDelimiter(delimeter)
+                .setMarker(marker)
+                .setLimit(pageSize);
+        return commandFactory.createListObjectsCommand(getAccount(), this, listInstructions).call();
+    }
 
     public void metadataSetFromHeaders() {
         this.staleHeaders = false;

--- a/src/main/java/org/javaswift/joss/instructions/ListInstructions.java
+++ b/src/main/java/org/javaswift/joss/instructions/ListInstructions.java
@@ -7,12 +7,16 @@ public class ListInstructions {
     public static final String LIMIT_NAME = "limit";
 
     public static final String PREFIX_NAME = "prefix";
+    
+    public static final String  DELIMITER_NAME = "delimiter";
 
     private String marker;
 
     private Integer limit;
 
     private String prefix;
+    
+    private String delimiter;
 
     public ListInstructions setMarker(String marker) {
         this.marker = marker;
@@ -28,12 +32,18 @@ public class ListInstructions {
         this.prefix = prefix;
         return this;
     }
+    
+    public ListInstructions setDelimiter(String delimiter) {
+    	this.delimiter = delimiter;
+    	return this;
+    }
 
     public QueryParameters getQueryParameters() {
         return new ListQueryParameters(new QueryParameter[] {
             new QueryParameter(PREFIX_NAME, getPrefix()),
             new QueryParameter(MARKER_NAME, getMarker()),
-            new QueryParameter(LIMIT_NAME, getLimit())
+            new QueryParameter(LIMIT_NAME, getLimit()),
+            new QueryParameter(DELIMITER_NAME, getDelimiter())
         });
     }
 
@@ -47,6 +57,10 @@ public class ListInstructions {
 
     public String getPrefix() {
         return prefix;
+    }
+    
+    public String getDelimiter() {
+    	return delimiter;
     }
 
 }


### PR DESCRIPTION
The [Swift Documentation](http://docs.openstack.org/api/openstack-object-storage/1.0/content/pseudo-hierarchical-folders-directories.html) uses prefix and delimiter to allow the access of pseudo-directories. Swift already supports prefixes. This pull request adds delimiters to the container list() method.
