### PR TITLE
Added support for External authentication method

### DIFF
--- a/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
@@ -174,9 +174,14 @@ public class AccountConfig {
      *         password must be passed. Ideally, tenant ID and/or name are passed as well. JOSS can auto-
      *         discover the tenant if none is passed and if it can be resolved (one tenant for user).
      *     </li>
+	 *     <li>
+	 *         <b>EXTERNAL</b>; an implementation of the interface AccessProvider must be provided.
+	 *     </li>
      * </ul>
      */
     private AuthenticationMethod authenticationMethod = KEYSTONE;
+    
+    private AuthenticationMethod.AccessProvider accessProvider = null ;
 
     public void setTenantName(String tenantName) {
         this.tenantName = tenantName;
@@ -345,9 +350,17 @@ public class AccountConfig {
     public AuthenticationMethod getAuthenticationMethod() {
         return authenticationMethod;
     }
-
+    
     public void setAuthenticationMethod(AuthenticationMethod authenticationMethod) {
         this.authenticationMethod = authenticationMethod;
+    }
+    
+    public AuthenticationMethod.AccessProvider getAccessProvider () {
+    	return accessProvider ;
+    }
+
+    public void setAccessProvider (AuthenticationMethod.AccessProvider accessProvider) {
+    	this.accessProvider = accessProvider ;
     }
 
     public void setAuthenticationMethod(String authenticationMethod) {

--- a/src/main/java/org/javaswift/joss/client/factory/AuthenticationMethod.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AuthenticationMethod.java
@@ -1,5 +1,7 @@
 package org.javaswift.joss.client.factory;
 
+import org.javaswift.joss.model.Access;
+
 /**
  * <ul>
  *     <li>
@@ -14,10 +16,19 @@ package org.javaswift.joss.client.factory;
  *         <a href="https://github.com/openstack/swift/blob/master/swift/common/middleware/tempauth.py">TEMPAUTH</a>:
  *         if you have TempAuth enabled, you will use this option. Looks very similar to Basic authentication
  *     </li>
+ *     <li>
+ *         EXTERNAL:
+ *         an implementation of the interface AccessProvider must be provided
+ *     </li>
  * </ul>
  */
 public enum AuthenticationMethod {
     BASIC,
     KEYSTONE,
-    TEMPAUTH
+    TEMPAUTH,
+    EXTERNAL;
+    
+    public static interface AccessProvider {
+    	public Access authenticate () ;
+    }
 }

--- a/src/main/java/org/javaswift/joss/client/impl/ClientImpl.java
+++ b/src/main/java/org/javaswift/joss/client/impl/ClientImpl.java
@@ -88,7 +88,8 @@ public class ClientImpl extends AbstractClient<AccountImpl> {
                 accountConfig.getTenantName(),
                 accountConfig.getTenantId(),
                 accountConfig.getUsername(),
-                accountConfig.getPassword());
+                accountConfig.getPassword(),
+                accountConfig.getAccessProvider());
         LOG.info(
                 "JOSS / Attempting authentication with tenant name: " + accountConfig.getTenantName()+
                         ", tenant ID: "+accountConfig.getTenantId()+

--- a/src/main/java/org/javaswift/joss/client/mock/ClientMock.java
+++ b/src/main/java/org/javaswift/joss/client/mock/ClientMock.java
@@ -66,7 +66,8 @@ public class ClientMock extends AbstractClient<AccountMock> {
                     accountConfig.getTenantName(),
                     accountConfig.getTenantId(),
                     accountConfig.getUsername(),
-                    accountConfig.getPassword()).call();
+                    accountConfig.getPassword(), 
+                    accountConfig.getAccessProvider()).call();
         }
         return new AccountMock(swift);
     }

--- a/src/main/java/org/javaswift/joss/command/impl/factory/AuthenticationCommandFactoryImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/factory/AuthenticationCommandFactoryImpl.java
@@ -3,6 +3,7 @@ package org.javaswift.joss.command.impl.factory;
 import org.apache.http.client.HttpClient;
 import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.command.impl.identity.BasicAuthenticationCommandImpl;
+import org.javaswift.joss.command.impl.identity.ExternalAuthenticationCommandImpl;
 import org.javaswift.joss.command.impl.identity.KeystoneAuthenticationCommandImpl;
 import org.javaswift.joss.command.impl.identity.TempAuthAuthenticationCommandImpl;
 import org.javaswift.joss.command.shared.factory.AuthenticationCommandFactory;
@@ -15,11 +16,13 @@ public class AuthenticationCommandFactoryImpl implements AuthenticationCommandFa
     @Override
     public AuthenticationCommand createAuthenticationCommand(HttpClient httpClient, AuthenticationMethod authenticationMethod,
                                                              String url, String tenantName, String tenantId,
-                                                             String username, String password) {
+                                                             String username, String password, AuthenticationMethod.AccessProvider accessProvier) {
         if (authenticationMethod == BASIC) {
             return new BasicAuthenticationCommandImpl(httpClient, url, username, password, tenantName);
         } else if (authenticationMethod == TEMPAUTH) {
             return new TempAuthAuthenticationCommandImpl(httpClient, url, username, password, tenantName);
+        } else if (authenticationMethod == EXTERNAL) {
+        	return new ExternalAuthenticationCommandImpl (httpClient, url, accessProvier) ;
         } else { // KEYSTONE
             return new KeystoneAuthenticationCommandImpl(httpClient, url, tenantName, tenantId, username, password);
         }

--- a/src/main/java/org/javaswift/joss/command/impl/identity/ExternalAuthenticationCommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/ExternalAuthenticationCommandImpl.java
@@ -1,0 +1,23 @@
+package org.javaswift.joss.command.impl.identity;
+
+import org.apache.http.client.HttpClient;
+import org.javaswift.joss.client.factory.AuthenticationMethod;
+import org.javaswift.joss.model.Access;
+
+public class ExternalAuthenticationCommandImpl extends AbstractSimpleAuthenticationCommandImpl {
+
+	private final AuthenticationMethod.AccessProvider accessProvier ;
+	
+    public ExternalAuthenticationCommandImpl(HttpClient httpClient, String url, AuthenticationMethod.AccessProvider accessProvier) {
+        super(httpClient, url);
+        if (accessProvier == null)
+        	throw new NullPointerException () ;
+        this.accessProvier = accessProvier ;
+    }
+    
+    @Override
+    public Access call() {
+    	return accessProvier.authenticate() ;
+    }
+}
+

--- a/src/main/java/org/javaswift/joss/command/mock/factory/AuthenticationCommandFactoryMock.java
+++ b/src/main/java/org/javaswift/joss/command/mock/factory/AuthenticationCommandFactoryMock.java
@@ -18,7 +18,7 @@ public class AuthenticationCommandFactoryMock implements AuthenticationCommandFa
     @Override
     public AuthenticationCommand createAuthenticationCommand(HttpClient httpClient, AuthenticationMethod authenticationMethod,
                                                              String url, String tenantName, String tenantId,
-                                                             String username, String password) {
+                                                             String username, String password, AuthenticationMethod.AccessProvider accessProvier) {
         return new AuthenticationCommandMock(swift, url, tenantName, tenantId, username, password);
     }
 

--- a/src/main/java/org/javaswift/joss/command/shared/factory/AuthenticationCommandFactory.java
+++ b/src/main/java/org/javaswift/joss/command/shared/factory/AuthenticationCommandFactory.java
@@ -8,6 +8,6 @@ public interface AuthenticationCommandFactory {
 
     AuthenticationCommand createAuthenticationCommand(HttpClient httpClient, AuthenticationMethod authenticationMethod,
                                                       String url, String tenantName, String tenantId,
-                                                      String username, String password);
+                                                      String username, String password, AuthenticationMethod.AccessProvider accessProvier);
 
 }

--- a/src/test/java/org/javaswift/joss/command/impl/factory/AuthenticationCommandFactoryImplTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/factory/AuthenticationCommandFactoryImplTest.java
@@ -2,13 +2,16 @@ package org.javaswift.joss.command.impl.factory;
 
 import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.command.impl.identity.BasicAuthenticationCommandImpl;
+import org.javaswift.joss.command.impl.identity.ExternalAuthenticationCommandImpl;
 import org.javaswift.joss.command.impl.identity.KeystoneAuthenticationCommandImpl;
 import org.javaswift.joss.command.impl.identity.TempAuthAuthenticationCommandImpl;
+import org.javaswift.joss.model.Access;
 import org.junit.Test;
 
 import static org.javaswift.joss.client.factory.AuthenticationMethod.BASIC;
 import static org.javaswift.joss.client.factory.AuthenticationMethod.KEYSTONE;
 import static org.javaswift.joss.client.factory.AuthenticationMethod.TEMPAUTH;
+import static org.javaswift.joss.client.factory.AuthenticationMethod.EXTERNAL;
 import static org.junit.Assert.assertEquals;
 
 public class AuthenticationCommandFactoryImplTest {
@@ -24,7 +27,17 @@ public class AuthenticationCommandFactoryImplTest {
 
     protected void assertAuthenticationMechanism(AuthenticationCommandFactoryImpl  factory,
                                                  AuthenticationMethod authenticationMethod, Class instance) {
-        assertEquals(instance, factory.createAuthenticationCommand(null, authenticationMethod, "http://nowhere.com", null, null, null, null).getClass());
+        assertEquals(instance, factory.createAuthenticationCommand(null, authenticationMethod, "http://nowhere.com", null, null, null, null, null).getClass());
     }
 
+    @Test
+    public void externalAuthenticationMechanisms() {
+        AuthenticationCommandFactoryImpl factory = new AuthenticationCommandFactoryImpl();
+        assertEquals(ExternalAuthenticationCommandImpl.class, factory.createAuthenticationCommand(null, EXTERNAL, "http://nowhere.com", null, null, null, null, new AuthenticationMethod.AccessProvider() {
+			@Override
+			public Access authenticate() {
+				return null ;
+			}
+		}).getClass());
+    }
 }


### PR DESCRIPTION
A new authentication mechanism is proposed, in which the user can implement his/her own _authenticate_ method. 

~~**Note: it is not fully tested yet**(currently, it seems to authenticate properly, but the re-authentication using a real back-end has not been tested yet).~~  (see next comment)

To use it, the method AuthenticationMethod.EXTERNAL must be selected, and an implementation of the interface AuthenticationMethod.AccessProvider must be provided.

```
public class MyAccessProvider implements AuthenticationMethod.AccessProvider{

    ...

    @Override
    public Access authenticate() {
        AccessBasic access = new AccessBasic();
        access.setToken(...);
        access.setUrl(...);
        return access ;
    }
}
```

It can be tested using this repository (and version 0.9.8-SNAPSHOT):

```
<repositories>  
    <repository>
        <id>joss-mvn-repo</id>
        <url>https://raw.github.com/roikku/joss/mvn-repo/</url>
        <snapshots>
            <enabled>true</enabled>
            <updatePolicy>always</updatePolicy>
        </snapshots>
    </repository>
</repositories>
```
