### PR TITLE
Add ability to clear DeleteAt and DeleteAfter headers

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
@@ -233,19 +233,23 @@ public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<Obj
         return this;
     }
 
-    public StoredObject setDeleteAfter(long seconds) {
+    public StoredObject setDeleteAfter(Long seconds) {
         checkForInfo();
         info.setDeleteAt(null);
-        info.setDeleteAfter(new DeleteAfter(seconds));
+        info.setDeleteAfter(seconds == null ? null : new DeleteAfter(seconds));
         commandFactory.createObjectMetadataCommand(
                 getAccount(), getContainer(), this, info.getHeadersIncludingHeader(info.getDeleteAfter())).call();
         return this;
     }
 
+    public StoredObject setDeleteAfter(long seconds) {
+        return this.setDeleteAfter(new Long(seconds));
+    }
+
     @Override
     public StoredObject setDeleteAt(Date date) {
         checkForInfo();
-        info.setDeleteAt(new DeleteAt(date));
+        info.setDeleteAt(date == null ? null : new DeleteAt(date));
         saveSpecificMetadata();
         return this;
     }

--- a/src/main/java/org/javaswift/joss/model/StoredObject.java
+++ b/src/main/java/org/javaswift/joss/model/StoredObject.java
@@ -123,9 +123,17 @@ public interface StoredObject extends ObjectStoreEntity, Comparable<DirectoryOrO
     public StoredObject setDeleteAfter(long seconds);
 
     /**
+     * Schedules the object to be deleted after a fixed period of x seconds
+     * @param seconds the number of seconds to wait before deleting the content. If seconds is null delete after header
+     *                will be cleared
+     * @return this
+     */
+    public StoredObject setDeleteAfter(Long seconds);
+
+    /**
     * Schedules the object to be deleted at a fixed date. Be careful using this method, since the server's date
     * may be different from yours.
-    * @param date the date at which to delete the content
+    * @param date the date at which to delete the content. If date is null delete at header will be cleared
     * @return this
     */
     public StoredObject setDeleteAt(Date date);

--- a/src/test/java/org/javaswift/joss/client/impl/StoredObjectImplTest.java
+++ b/src/test/java/org/javaswift/joss/client/impl/StoredObjectImplTest.java
@@ -255,6 +255,14 @@ public class StoredObjectImplTest extends BaseCommandTest {
     }
 
     @Test
+    public void removeDeleteAt() throws IOException, DateParseException {
+        expectStatusCode(202, false);
+        prepareMetadata();
+        object.setDeleteAt(null);
+        verifyHeaderValue(null, X_DELETE_AT, "POST");
+    }
+
+    @Test
     public void setDeleteAfter() throws IOException {
         expectStatusCode(202, false);
         prepareMetadata();
@@ -262,6 +270,15 @@ public class StoredObjectImplTest extends BaseCommandTest {
         verifyHeaderValue("42", X_DELETE_AFTER, "POST");
         verifyHeaderValue(null, X_DELETE_AT, "POST");
    }
+
+    @Test
+    public void removeDeleteAfter() throws IOException, DateParseException {
+        expectStatusCode(202, false);
+        prepareMetadata();
+        object.setDeleteAfter(null);
+        verifyHeaderValue(null, X_DELETE_AFTER, "POST");
+        verifyHeaderValue(null, X_DELETE_AT, "POST");
+    }
 
     @Test
     public void deleteObject() {

--- a/src/test/java/org/javaswift/joss/headers/object/DeleteAfterTest.java
+++ b/src/test/java/org/javaswift/joss/headers/object/DeleteAfterTest.java
@@ -9,5 +9,4 @@ public class DeleteAfterTest extends AbstractHeaderTest {
     public void testAddHeader() {
         testHeader(new DeleteAfter(30));
     }
-
 }


### PR DESCRIPTION
Currently there is no way to clear the DeleteAt and DeleteAfter header after either of them has been set. Added the ability to do that. This requires a contract change for StoredObject class. Retained the old set method for backward compatibility. 
