### PR TITLE
Bugfix: Updating metadata on a segmented object no longer drops the manifest header

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/object/ObjectManifest.java
+++ b/src/main/java/org/javaswift/joss/headers/object/ObjectManifest.java
@@ -25,6 +25,9 @@ public class ObjectManifest extends SimpleHeader {
     }
 
     public static ObjectManifest fromResponse(HttpResponse response) {
-    	return new ObjectManifest(convertResponseHeader(response, X_OBJECT_MANIFEST));
+    	String manifest = convertResponseHeader(response, X_OBJECT_MANIFEST);
+    	if (manifest == null)
+    		return null;
+    	return new ObjectManifest(manifest);
     }
 }

--- a/src/main/java/org/javaswift/joss/information/ObjectInformation.java
+++ b/src/main/java/org/javaswift/joss/information/ObjectInformation.java
@@ -79,19 +79,24 @@ public class ObjectInformation extends AbstractInformation {
         }
         headers.add(header);
     }
-    
+
     public String getManifest () {
     	return (manifest == null) ? (null) : (manifest.getHeaderValue()) ;
     }
-    
+
     public void setManifest(ObjectManifest manifest) {
         this.manifest = manifest;
+    }
+
+    protected ObjectManifest getObjectManifest() {
+    	return this.manifest;
     }
 
     public Collection<Header> getHeaders() {
         Collection<Header> headers = new ArrayList<Header>();
         addHeader(headers, getDeleteAfter());
         addHeader(headers, getDeleteAt());
+        addHeader(headers, getObjectManifest());
         headers.addAll(getMetadata()); // The original metadata must be passed as well, otherwise it's deleted
         return headers;
     }

--- a/src/test/java/org/javaswift/joss/information/ObjectInformationTest.java
+++ b/src/test/java/org/javaswift/joss/information/ObjectInformationTest.java
@@ -26,7 +26,7 @@ public class ObjectInformationTest {
         info.setContentType(new ObjectContentType("text/plain"));
         info.setManifest(new ObjectManifest("container_segments/object"));
         Collection<Header> headers = info.getHeadersIncludingHeader(new ObjectContentType("image/png"));
-        assertEquals(5, headers.size());
+        assertEquals(6, headers.size());
         for (Header header : headers) {
             if (ObjectContentType.CONTENT_TYPE.equals(header.getHeaderName())) {
                 assertEquals("image/png", header.getHeaderValue());


### PR DESCRIPTION
Updating metadata on a segmented object caused the X-Object-manifest header to be dropped. In case you wonder about the ObjectManifest change: Without it, an X-Object-manifest header with an empty value would be added to any non-segmented object which would also cause the object to be broken.
