### PR TITLE
Segmentation support for InputStreams with known size

### DIFF
--- a/src/main/java/org/javaswift/joss/instructions/SegmentationPlanBoundedInputStream.java
+++ b/src/main/java/org/javaswift/joss/instructions/SegmentationPlanBoundedInputStream.java
@@ -1,0 +1,37 @@
+package org.javaswift.joss.instructions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.input.BoundedInputStream;
+import org.javaswift.joss.instructions.SegmentationPlan;
+
+public class SegmentationPlanBoundedInputStream extends SegmentationPlan {
+
+	private long length;
+	private InputStream inputStream;
+
+	public SegmentationPlanBoundedInputStream(InputStream inputStream, long length, Long segmentationSize) {
+		super(segmentationSize);
+		this.length = length;
+		this.inputStream = inputStream;
+	}
+
+	@Override
+	protected Long getFileLength() {
+		return length;
+	}
+
+	@Override
+	protected InputStream createSegment() throws IOException {
+		BoundedInputStream stream = new BoundedInputStream(inputStream, segmentationSize);
+		stream.setPropagateClose(false);
+		return stream;
+	}
+
+	@Override
+	public void close() throws IOException {
+		inputStream.close();
+	}
+
+}

--- a/src/main/java/org/javaswift/joss/instructions/UploadInstructions.java
+++ b/src/main/java/org/javaswift/joss/instructions/UploadInstructions.java
@@ -64,6 +64,10 @@ public class UploadInstructions {
         this.uploadPayload = new UploadPayloadByteArray(fileToUpload);
     }
 
+	public UploadInstructions(InputStream inputStream, long length) {
+		this.uploadPayload = new UploadPayloadBoundedInputStream(inputStream, length);
+	}
+
     /**
      * Facade method for checking out the payload to see if must be segmented. Used
      * internally.

--- a/src/main/java/org/javaswift/joss/instructions/UploadInstructions.java
+++ b/src/main/java/org/javaswift/joss/instructions/UploadInstructions.java
@@ -52,20 +52,24 @@ public class UploadInstructions {
     /** Size at which a file must be segmented into smaller pieces */
     private Long segmentationSize = MAX_SEGMENTATION_SIZE;
 
+    public UploadInstructions(UploadPayload uploadPayload) {
+    	this.uploadPayload = uploadPayload;
+    }
+
     public UploadInstructions(File fileToUpload) {
-        this.uploadPayload = new UploadPayloadFile(fileToUpload);
+        this(new UploadPayloadFile(fileToUpload));
     }
 
     public UploadInstructions(InputStream inputStream) {
-        this.uploadPayload = new UploadPayloadInputStream(inputStream);
+        this(new UploadPayloadInputStream(inputStream));
     }
 
     public UploadInstructions(byte[] fileToUpload) {
-        this.uploadPayload = new UploadPayloadByteArray(fileToUpload);
+        this(new UploadPayloadByteArray(fileToUpload));
     }
 
 	public UploadInstructions(InputStream inputStream, long length) {
-		this.uploadPayload = new UploadPayloadBoundedInputStream(inputStream, length);
+		this(new UploadPayloadBoundedInputStream(inputStream, length));
 	}
 
     /**

--- a/src/main/java/org/javaswift/joss/instructions/UploadPayloadBoundedInputStream.java
+++ b/src/main/java/org/javaswift/joss/instructions/UploadPayloadBoundedInputStream.java
@@ -1,0 +1,42 @@
+package org.javaswift.joss.instructions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.InputStreamEntity;
+import org.javaswift.joss.headers.object.Etag;
+import org.javaswift.joss.instructions.SegmentationPlan;
+import org.javaswift.joss.instructions.UploadPayload;
+
+public class UploadPayloadBoundedInputStream extends UploadPayload {
+
+	private InputStream inputStream;
+	private long length;
+
+	public UploadPayloadBoundedInputStream(final InputStream inputStream, long length) {
+		this.inputStream = inputStream;
+		this.length = length;
+	}
+
+	@Override
+	public HttpEntity getEntity() {
+		return new InputStreamEntity(inputStream, -1);
+	}
+
+	@Override
+	public boolean mustBeSegmented(Long segmentationSize) {
+		return length > segmentationSize;
+	}
+
+	@Override
+	public Etag getEtag() throws IOException {
+		return null;
+	}
+
+	@Override
+	public SegmentationPlan getSegmentationPlan(Long segmentationSize) throws IOException {
+		return new SegmentationPlanBoundedInputStream(inputStream, length, segmentationSize);
+	}
+
+}


### PR DESCRIPTION
Also added a new constructor to UploadInstructions to enable arbitrary payloads and segmentation plans. The other constructors could probably be changed to public static convenience methods using the new constructor, but I did not want to break stuff for current users.
