### PR TITLE
Fix #77 Ensure slashes remain slashes in encoded object URL

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
@@ -105,7 +105,8 @@ public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<Obj
 
     @Override
     public String getPathForEntity() throws UnsupportedEncodingException {
-        return getContainer().getPath() + "/" + SpaceURLEncoder.encode(getName());
+		return getContainer().getPath() + "/"
+				+ SpaceURLEncoder.encode(getName()).replace("%2F", "/");
     }
 
     public void setLastModified(Date date) {


### PR DESCRIPTION
Unlike directory queries, which are sent in the query part of the
request, the access to objects is sent in the path part. Thus, we
must not encode slashes as they are an essential component of the full
path to an object.

This patch does the full encoding of the path, and then reverts all
occurrences of %2F to a plain '/'.
