### PR TITLE
AccessBasic getTempUrlPrefix should return path w/o http://hostname

### DIFF
--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessBasic.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessBasic.java
@@ -1,5 +1,9 @@
 package org.javaswift.joss.command.shared.identity.access;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 import org.javaswift.joss.model.Access;
 
@@ -41,6 +45,11 @@ public class AccessBasic implements Access {
 
     @Override
     public String getTempUrlPrefix(TempUrlHashPrefixSource tempUrlHashPrefixSource) {
-        return url.endsWith("/") ? url.substring(0, url.length()-1) : url;
+        try {
+            final String path = new URL(url).getPath();
+            return path.endsWith("/") ? path.substring(0, path.length()-1) : path;
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessBasicTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessBasicTest.java
@@ -9,8 +9,8 @@ public class AccessBasicTest {
 
     @Test
     public void settersAndGetters() {
-        String url = "http://www.abc.nl/";
-        String urlNoSlashAtEnd = "http://www.abc.nl";
+        String url = "http://www.abc.nl/path/";
+        String pathNoSlashAtEnd = "/path";
         String token = "cafebabe";
         AccessBasic access = new AccessBasic();
         access.setUrl(url);
@@ -19,9 +19,9 @@ public class AccessBasicTest {
         access.setToken(token);
         assertEquals(token, access.getToken());
         access.setPreferredRegion(null); // does nothing
-        assertEquals(urlNoSlashAtEnd, access.getTempUrlPrefix(null));
-        access.setUrl(urlNoSlashAtEnd);
-        assertEquals(urlNoSlashAtEnd, access.getTempUrlPrefix(null));
+        assertEquals(pathNoSlashAtEnd, access.getTempUrlPrefix(null));
+        access.setUrl(url.substring(0,url.length()-1));
+        assertEquals(pathNoSlashAtEnd, access.getTempUrlPrefix(null));
         assertTrue(access.isTenantSupplied());
     }
 }


### PR DESCRIPTION
StoredObject.getTempGetUrl doesn't work for AccessBasic since the signature is calculated according to absolute path (http://hostname/v1/account) and not relative path (/v1/account) as explained [here](http://docs.openstack.org/developer/swift/api/temporary_url_middleware.html) and as done in [AccessTenant](https://github.com/javaswift/joss/blob/master/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessTenant.java#L43).
