### PR TITLE
Fix version to have SNAPSHOT during dev cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.javaswift</groupId>
     <artifactId>joss</artifactId>
-    <version>0.9.10</version>
+    <version>0.9.11-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Java OpenStack Storage</name>
     <description>Java Client library for OpenStack Storage (Swift)</description>


### PR DESCRIPTION
Maven best practice recommend using SNAPSHOT prefix on artifact id version during development cycle. As release 0.9.10 is already available, moving this to 0.9.11-SNAPSHOT.