### PR TITLE
Multiple code improvements - squid:RedundantThrowsDeclarationCheck, squid:ClassVariableVisibilityCheck

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractContainer.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractContainer.java
@@ -118,8 +118,8 @@ public abstract class AbstractContainer extends AbstractObjectStoreEntity<Contai
                 expires;
 
         FormPost formPost = new FormPost();
-        formPost.expires = expires;
-        formPost.signature = HashSignature.getSignature(getAccount().getHashPassword(), plainText);
+        formPost.setExpires(expires);
+        formPost.setSignature(HashSignature.getSignature(getAccount().getHashPassword(), plainText));
         return formPost;
     }
 

--- a/src/main/java/org/javaswift/joss/exception/HttpStatusExceptionUtil.java
+++ b/src/main/java/org/javaswift/joss/exception/HttpStatusExceptionUtil.java
@@ -2,11 +2,11 @@ package org.javaswift.joss.exception;
 
 public class HttpStatusExceptionUtil {
 
-    public static void throwException(int httpStatus, CommandExceptionError customError) throws CommandException {
+    public static void throwException(int httpStatus, CommandExceptionError customError) {
         throw getException(httpStatus, customError);
     }
 
-    public static void throwException(int httpStatus) throws CommandException {
+    public static void throwException(int httpStatus) {
         throw getException(httpStatus, null);
     }
 

--- a/src/main/java/org/javaswift/joss/exception/HttpStatusToExceptionMapper.java
+++ b/src/main/java/org/javaswift/joss/exception/HttpStatusToExceptionMapper.java
@@ -40,7 +40,7 @@ public enum HttpStatusToExceptionMapper {
         return this.error;
     }
 
-    public CommandException getException(CommandExceptionError customError) throws CommandException {
+    public CommandException getException(CommandExceptionError customError) {
         CommandExceptionError showError = customError == null ? getError() : customError;
         try {
             Constructor constructor = getExceptionToThrow().getDeclaredConstructor(new Class[]{Integer.class, CommandExceptionError.class});

--- a/src/main/java/org/javaswift/joss/model/FormPost.java
+++ b/src/main/java/org/javaswift/joss/model/FormPost.java
@@ -2,8 +2,23 @@ package org.javaswift.joss.model;
 
 public class FormPost {
 
-    public long expires;
+    private long expires;
 
-    public String signature;
+    private String signature;
 
+    public long getExpires() {
+        return expires;
+    }
+
+    public void setExpires(long expires) {
+        this.expires = expires;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
 }

--- a/src/test/java/org/javaswift/joss/client/impl/ContainerImplTest.java
+++ b/src/test/java/org/javaswift/joss/client/impl/ContainerImplTest.java
@@ -157,9 +157,9 @@ public class ContainerImplTest extends BaseCommandTest {
         useFixedDateForToday(todayInMS);
         // Check whether the secure URL contains the right signature and expiry date
         FormPost formPost = container.getFormPost(redirectUrl, maxFileSize, maxFileCount, oneDayInSeconds);
-        String plainText = "/internal/path/alpha\n"+redirectUrl+"\n"+maxFileSize+"\n"+maxFileCount+"\n"+formPost.expires;
+        String plainText = "/internal/path/alpha\n"+redirectUrl+"\n"+maxFileSize+"\n"+maxFileCount+"\n"+formPost.getExpires();
         String signature = HashSignature.getSignature(password, plainText);
-        assertEquals("The signature must match", signature, formPost.signature);
+        assertEquals("The signature must match", signature, formPost.getSignature());
     }
 
     @Test


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava