### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractPaginationMap.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractPaginationMap.java
@@ -56,7 +56,7 @@ public abstract class AbstractPaginationMap<Child extends ListSubject> implement
                     locationInPage = 0;
                 }
             }
-            recordsToGo -= children.size() == 0 ? recordsToGo : (children.size() < blockSize ? children.size() : blockSize);
+            recordsToGo -= children.isEmpty() ? recordsToGo : (children.size() < blockSize ? children.size() : blockSize);
             allChildren.addAll(children);
         }
         if (locationInPage == 0) { // Remove last page if no elements follow it

--- a/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenants.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenants.java
@@ -15,7 +15,7 @@ public class Tenants {
     @JsonIgnore
     public Tenant getTenant() {
         List<Tenant> enabledTenants = getEnabledTenants();
-        if (enabledTenants.size() < 1) {
+        if (enabledTenants.isEmpty()) {
             throw new CommandException("No enabled tenant found during auto-discovery");
         }
         if (enabledTenants.size() > 1) {

--- a/src/main/java/org/javaswift/joss/swift/SwiftContainer.java
+++ b/src/main/java/org/javaswift/joss/swift/SwiftContainer.java
@@ -84,7 +84,7 @@ public class SwiftContainer implements ListSubject {
 
         return new SwiftResult<Collection<DirectoryOrObject>>(
                 pagedObjects,
-                pagedObjects.size() == 0 ? HttpStatus.SC_NO_CONTENT : HttpStatus.SC_OK
+                pagedObjects.isEmpty() ? HttpStatus.SC_NO_CONTENT : HttpStatus.SC_OK
         );
     }
 
@@ -102,7 +102,7 @@ public class SwiftContainer implements ListSubject {
 
         return new SwiftResult<Collection<StoredObject>>(
                 objects,
-                objects.size() == 0 ? HttpStatus.SC_NO_CONTENT : HttpStatus.SC_OK
+                objects.isEmpty() ? HttpStatus.SC_NO_CONTENT : HttpStatus.SC_OK
         );
     }
 

--- a/src/main/java/org/javaswift/joss/swift/scheduled/ObjectDeleter.java
+++ b/src/main/java/org/javaswift/joss/swift/scheduled/ObjectDeleter.java
@@ -52,7 +52,7 @@ public class ObjectDeleter implements Runnable {
         }
         objectsToDelete.removeAll(objectsToDeleteNow);
 
-        if (objectsToDelete.size() == 0) {
+        if (objectsToDelete.isEmpty()) {
             shutdown();
         }
     }

--- a/src/main/java/org/javaswift/joss/swift/statusgenerator/StatusCursor.java
+++ b/src/main/java/org/javaswift/joss/swift/statusgenerator/StatusCursor.java
@@ -19,7 +19,7 @@ public class StatusCursor {
         if (position == statusList.size()) {
             position = 0;
         }
-        if (statusList.size() == 0) {
+        if (statusList.isEmpty()) {
             return -1;
         }
         return statusList.get(position++);


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava