### PR TITLE
Multiple code improvements - squid:S00116, squid:S2325

### DIFF
--- a/src/main/java/org/javaswift/joss/client/website/AbstractWebsite.java
+++ b/src/main/java/org/javaswift/joss/client/website/AbstractWebsite.java
@@ -113,7 +113,7 @@ public abstract class AbstractWebsite extends AbstractContainer implements Websi
         target.cleanup();
     }
 
-    private void deleteObjects(FileObjects source, FileObjects target) {
+    private static void deleteObjects(FileObjects source, FileObjects target) {
         for (String targetPath : target.keys()) {
             if (target.ignore(targetPath)) {
                 continue;
@@ -126,7 +126,7 @@ public abstract class AbstractWebsite extends AbstractContainer implements Websi
     }
 
     @SuppressWarnings("unchecked")
-    private void saveObjects(FileObjects source, FileObjects target) {
+    private static void saveObjects(FileObjects source, FileObjects target) {
         for (String sourcePath : source.keys()) {
             FileObject sourceObject = source.get(sourcePath);
             FileObject targetObject = target.get(sourcePath);

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/Metadata.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/Metadata.java
@@ -7,7 +7,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Metadata {
 
-    public boolean is_admin;
+    public boolean isAdmin;
 
     public List<String> roles;
 

--- a/src/main/java/org/javaswift/joss/headers/object/range/AbstractRange.java
+++ b/src/main/java/org/javaswift/joss/headers/object/range/AbstractRange.java
@@ -16,8 +16,8 @@ import java.util.Arrays;
  */
 public abstract class AbstractRange extends Header {
 
-    public String RANGE_HEADER_NAME = "Range";
-    public String RANGE_HEADER_VALUE_PREFIX = "bytes=";
+    public String rangeHeaderName = "Range";
+    public String rangeHeaderValuePrefix = "bytes=";
 
     protected long offset;
 
@@ -30,14 +30,14 @@ public abstract class AbstractRange extends Header {
 
     public String getHeaderValue() {
         return
-            RANGE_HEADER_VALUE_PREFIX+
+            rangeHeaderValuePrefix+
                 (offset >= 0 ? Long.toString(offset) : "") +
                 "-" +
                 (length >= 0 ? Long.toString(length) : "");
     }
 
     public String getHeaderName() {
-        return RANGE_HEADER_NAME;
+        return rangeHeaderName;
     }
 
     public abstract long getFrom(int byteArrayLength);

--- a/src/main/java/org/javaswift/joss/instructions/QueryParameter.java
+++ b/src/main/java/org/javaswift/joss/instructions/QueryParameter.java
@@ -30,7 +30,7 @@ public class QueryParameter implements NameValuePair {
         return getValue() == null ? null : urlEncode(getName()) + "=" + urlEncode(getValue());
     }
 
-    private String urlEncode(String value) {
+    private static String urlEncode(String value) {
         try {
             return SpaceURLEncoder.encode(value);
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/org/javaswift/joss/swift/Swift.java
+++ b/src/main/java/org/javaswift/joss/swift/Swift.java
@@ -393,7 +393,7 @@ public class Swift {
         return foundObject.saveMetadata(headers);
     }
 
-    private <T extends Header> T getSpecificHeader(Collection<? extends Header> headers, Class<T> matchClass) {
+    private static <T extends Header> T getSpecificHeader(Collection<? extends Header> headers, Class<T> matchClass) {
         for (Header header : headers) {
             if (matchClass.isInstance(header)) {
                 return (T)header;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00116 - Field names should comply with a naming convention.
squid:S2325 - "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S2325
Please let me know if you have any questions.
George Kankava