### PR TITLE
Issue #104: Check if TenantName or TenantId are null or empty

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationCommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationCommandImpl.java
@@ -33,7 +33,7 @@ public class KeystoneAuthenticationCommandImpl extends AbstractCommand<HttpPost,
     }
 
     private void setTenantSupplied(String tenantName, String tenantId) {
-        this.tenantSupplied = tenantName != null || tenantId != null;
+        tenantSupplied = tenantName != null && !tenantName.isEmpty() || tenantId != null && !tenantId.isEmpty();
     }
 
     private boolean isTenantSupplied() {

--- a/src/test/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationCommandImplTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationCommandImplTest.java
@@ -37,6 +37,20 @@ public class KeystoneAuthenticationCommandImplTest extends BaseCommandTest {
     }
 
     @Test
+    public void emptyTenantNameSupplied() {
+        AuthenticationCommand command = new KeystoneAuthenticationCommandImpl(httpClient, "someurl", "", null, "user", "pwd");
+        Access access = command.call();
+        assertFalse(access.isTenantSupplied());
+    }
+
+    @Test
+    public void emptyTenantIdSupplied() {
+        AuthenticationCommand command = new KeystoneAuthenticationCommandImpl(httpClient, "someurl", null, "", "user", "pwd");
+        Access access = command.call();
+        assertFalse(access.isTenantSupplied());
+    }
+
+    @Test
     public void noTenantNameSupplied() throws IOException {
         AuthenticationCommand command = new KeystoneAuthenticationCommandImpl(httpClient, "someurl", null, "tenantid", "user", "pwd");
         Access access = command.call();


### PR DESCRIPTION
Check if tenantName and tenantId are empty as well as null to avoid setting tenantSupplied incorrectly.
Added unit tests to validate the change.
