### PR TITLE
Configure jackson ObjectMapper to work in secure environment

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
@@ -132,6 +132,9 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
 
     protected ObjectMapper createObjectMapper(boolean dealWithRootValue) {
         ObjectMapper objectMapper = new ObjectMapper();
+        // make the ObjectMapper more friendly in secure environment
+        objectMapper.configure(DeserializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
+        objectMapper.configure(SerializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         if (dealWithRootValue) {
             objectMapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
             objectMapper.configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/Authentication.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/Authentication.java
@@ -1,5 +1,7 @@
 package org.javaswift.joss.command.shared.identity.authentication;
 
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
@@ -11,7 +13,12 @@ public class Authentication {
     private String tenantId;
 
     public Authentication(final String tenantName, String tenantId, final String username, final String password) {
-        this.passwordCredentials = new PasswordCredentials(username, password);
+        this(tenantName, tenantId, new PasswordCredentials(username, password));
+    }
+
+    @JsonCreator
+    public Authentication(@JsonProperty final String tenantName, @JsonProperty String tenantId, @JsonProperty PasswordCredentials passwordCredentials) {
+        this.passwordCredentials = passwordCredentials;
         this.tenantName = tenantName;
         this.tenantId = tenantId;
     }

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/PasswordCredentials.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/PasswordCredentials.java
@@ -1,12 +1,16 @@
 package org.javaswift.joss.command.shared.identity.authentication;
 
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
 public class PasswordCredentials {
 
     private String username;
 
     private String password;
 
-    public PasswordCredentials(final String username, final String password) {
+    @JsonCreator
+    public PasswordCredentials(@JsonProperty final String username, @JsonProperty final String password) {
         this.username = username;
         this.password = password;
     }

--- a/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
@@ -1,5 +1,6 @@
 package org.javaswift.joss.command.impl.account;
 
+import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.javaswift.joss.command.shared.account.ContainerListElement;
 import org.javaswift.joss.util.ClasspathTemplateResource;
@@ -15,6 +16,7 @@ public class ContainerListingTest {
     public void testUnmarshallingSingleElement() throws IOException {
         String jsonString = new ClasspathTemplateResource("/sample-container-listing.json").loadTemplate();
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         ContainerListElement listing = mapper.readValue(jsonString, ContainerListElement.class);
         assertEquals("Amersfoort", listing.name);
         assertEquals(48, listing.count);
@@ -25,6 +27,7 @@ public class ContainerListingTest {
     public void testUnmarshallingList() throws IOException {
         String jsonString = new ClasspathTemplateResource("/sample-container-list.json").loadTemplate();
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         ContainerListElement[] list = mapper.readValue(jsonString, ContainerListElement[].class);
         assertEquals(4, list.length);
     }

--- a/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessTest.java
@@ -23,6 +23,7 @@ public class AccessTest {
     public void testUnmarshalling() throws IOException {
         String jsonString = new ClasspathTemplateResource("/sample-access.json").loadTemplate();
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         mapper.configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);
         Access access = mapper.readValue(jsonString, AccessTenant.class);
         assertEquals("a376b74fbdb64a4986cd3234647ff6f8", access.getToken());

--- a/src/test/java/org/javaswift/joss/command/shared/identity/authentication/AuthenticationTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/authentication/AuthenticationTest.java
@@ -13,6 +13,7 @@ public class AuthenticationTest {
     @Test
     public void testMarshalling() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
         Authentication auth = new Authentication("testtenant", "testtenantid", "testuser", "testpassword");
         assertEquals("{\"auth\":{\"passwordCredentials\":{\"username\":\"testuser\",\"password\":\"testpassword\"},\"tenantName\":\"testtenant\",\"tenantId\":\"testtenantid\"}}", mapper.writeValueAsString(auth));

--- a/src/test/java/org/javaswift/joss/command/shared/identity/tenant/TenantsTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/tenant/TenantsTest.java
@@ -1,6 +1,7 @@
 package org.javaswift.joss.command.shared.identity.tenant;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
 import org.javaswift.joss.exception.CommandException;
 import org.junit.Test;
 
@@ -15,6 +16,7 @@ public class TenantsTest {
     @Test
     public void marshalling() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         Tenant tenant = new Tenant();
         tenant.enabled = true;
         tenant.id = "tenant-id";


### PR DESCRIPTION
By default jackson requires supressAccessChecks permission to fix visilibity
on some members/constructors. This is not really needed in the context of
this project but can cause issues when joss is used with a SecurityManager:
- wikimedia/search-repository-swift#20
- wikimedia/search-repository-swift#21

By setting CAN_OVERRIDE_ACCESS_MODIFIERS to false jackson will not try to fix
access modifiers and will work in such environment.