### PR TITLE
Expose the Access interface from Account

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
@@ -171,6 +171,10 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
         return this.commandFactory.authenticate();
     }
 
+    public Access getAccess() {
+       return this.commandFactory.getAccess();
+    }
+
     @Override
     public String getPublicURL() {
         return this.commandFactory.getPublicHost();

--- a/src/main/java/org/javaswift/joss/command/mock/factory/AccountCommandFactoryMock.java
+++ b/src/main/java/org/javaswift/joss/command/mock/factory/AccountCommandFactoryMock.java
@@ -54,6 +54,11 @@ public class AccountCommandFactoryMock implements AccountCommandFactory {
     }
 
     @Override
+    public Access getAccess() {
+        return null;
+    }
+
+    @Override
     public AccountInformationCommand createAccountInformationCommand(Account account) {
         return new AccountInformationCommandMock(swift, account);
     }

--- a/src/main/java/org/javaswift/joss/command/shared/factory/AccountCommandFactory.java
+++ b/src/main/java/org/javaswift/joss/command/shared/factory/AccountCommandFactory.java
@@ -12,6 +12,8 @@ public interface AccountCommandFactory {
 
     public Access authenticate();
 
+    public Access getAccess();
+
     public String getPublicHost();
 
     public String getPrivateHost();

--- a/src/main/java/org/javaswift/joss/model/Account.java
+++ b/src/main/java/org/javaswift/joss/model/Account.java
@@ -38,7 +38,7 @@ public interface Account extends ObjectStoreEntity, ListHolder<Container> {
     Access authenticate();
 
     /**
-    * OFER: testing direct access to Access :)
+    * Obtain the Access interface
     * @ return the access element including the existing token
     */
     Access getAccess();

--- a/src/main/java/org/javaswift/joss/model/Account.java
+++ b/src/main/java/org/javaswift/joss/model/Account.java
@@ -38,6 +38,12 @@ public interface Account extends ObjectStoreEntity, ListHolder<Container> {
     Access authenticate();
 
     /**
+    * OFER: testing direct access to Access :)
+    * @ return the access element including the existing token
+    */
+    Access getAccess();
+
+    /**
     * Returns the URL which is used for the underlying stored objects
     * @return the URL of the underlying stored objects
     */


### PR DESCRIPTION
We have a usage scenario where we use JOSS to establish connection to an object store, and then use JOSS for some of the communication with the object store, but not all the communication with the object store.  To enable us to access the object store we need the Access interface.  We can get this interface by creating an Account and calling authenticate() on it.  However, authenticate will re-authenticate the account.  This can be expensive when going through keystone for short duration connections.  I would therefore like to expose Access from Account so all we need to do is just create an account.

In this pull request I have exposed the entire Access interface.  If you would rather I expose just the relevant fields in Access, I can make that happen.

Thanks!


Developer's Certificate of Origin 1.1

   By making a contribution to this project, I certify that:

   (a) The contribution was created in whole or in part by me and I
       have the right to submit it under the Apache License 2.0; or

   (b) The contribution is based upon previous work that, to the best
       of my knowledge, is covered under an appropriate open source
       license and I have the right under that license to submit that
       work with modifications, whether created in whole or in part
       by me, under the same open source license (unless I am
       permitted to submit under a different license), as indicated
       in the file; or

   (c) The contribution was provided directly to me by some other
       person who certified (a), (b) or (c) and I have not modified
       it.

   (d) I understand and agree that this project and the contribution
       are public and that a record of the contribution (including all
       personal information I submit with it, including my sign-off) is
       maintained indefinitely and may be redistributed consistent with
       this project or the open source license(s) involved.

Effi Ofer