### PR TITLE
Use the preferred region during reauthentication.

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
@@ -33,6 +33,8 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
 
     private ServerTime serverTime = new ServerTime(0);
 
+    private String preferredRegion = null;
+
     public AbstractAccount(AccountCommandFactory commandFactory, ContainerFactory<Container> containerFactory,
                            ContainerFactory<Website> websiteFactory, boolean allowCaching) {
         super(allowCaching);
@@ -109,6 +111,13 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
         return this;
     }
 
+    @Override
+    public Account setPreferredRegion(final String preferredRegion) {
+        LOG.info("JOSS / PreferredRegion: " + preferredRegion);
+        this.preferredRegion = preferredRegion;
+        return this;
+    }
+
     public boolean isAllowReauthenticate() {
         return this.allowReauthenticate;
     }
@@ -173,6 +182,11 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
 
     public Access getAccess() {
        return this.commandFactory.getAccess();
+    }
+
+    @Override
+    public String getPreferredRegion() {
+        return this.preferredRegion;
     }
 
     @Override

--- a/src/main/java/org/javaswift/joss/client/core/AbstractClient.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractClient.java
@@ -46,7 +46,8 @@ public abstract class AbstractClient<A extends Account> implements Client<A> {
                 .setPrivateHost(accountConfig.getPrivateHost())
                 .setAllowContainerCaching(accountConfig.isAllowContainerCaching())
                 .setAllowReauthenticate(accountConfig.isAllowReauthenticate())
-                .setHashPassword(accountConfig.getHashPassword());
+                .setHashPassword(accountConfig.getHashPassword())
+                .setPreferredRegion(accountConfig.getPreferredRegion());
     }
 
     protected Tenant autoDiscoverTenant(Account account) {

--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractSecureCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractSecureCommand.java
@@ -32,6 +32,9 @@ public abstract class AbstractSecureCommand<M extends HttpRequestBase, N> extend
         } catch (UnauthorizedException err) {
             if (account.isAllowReauthenticate()) {
                 Access access = account.authenticate();
+                if (account.getPreferredRegion() != null) {
+                    access.setPreferredRegion(account.getPreferredRegion());
+                }
                 setToken(access.getToken());
                 return super.call();
             }

--- a/src/main/java/org/javaswift/joss/model/Account.java
+++ b/src/main/java/org/javaswift/joss/model/Account.java
@@ -182,4 +182,16 @@ public interface Account extends ObjectStoreEntity, ListHolder<Container> {
     */
     boolean isTenantSupplied();
 
+    /**
+     * Returns the preferred region of the account. 
+     * @return the account's preferred region
+     */
+    String getPreferredRegion();
+
+    /**
+     * Set the preferred region for the account.
+     * @param preferredRegion the preferred region for the account
+     * @return instance of Account
+     */
+    Account setPreferredRegion(String preferredRegion);
 }

--- a/src/test/java/org/javaswift/joss/command/impl/core/AbstractSecureCommandTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/core/AbstractSecureCommandTest.java
@@ -8,6 +8,7 @@ import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 import org.javaswift.joss.client.impl.AccountImpl;
 import org.javaswift.joss.command.impl.container.CreateContainerCommandImpl;
 import org.javaswift.joss.command.shared.identity.AuthenticationCommand;
+import org.javaswift.joss.command.shared.identity.access.AbstractAccess;
 import org.javaswift.joss.command.shared.identity.access.AccessTenant;
 import org.javaswift.joss.exception.UnauthorizedException;
 import org.javaswift.joss.headers.ConnectionKeepAlive;
@@ -52,6 +53,19 @@ public class AbstractSecureCommandTest extends BaseCommandTest {
         }};
         this.account = new AccountImpl(authCommand, httpClient, defaultAccess, true, TempUrlHashPrefixSource.PUBLIC_URL_PATH, '/');
         new CreateContainerCommandImpl(this.account, httpClient, defaultAccess, account.getContainer("containerName")).call();
+    }
+
+    @Test
+    public void reauthenticateWithPreferredRegionSuccess(@Mocked final AuthenticationCommand authCommand) {
+        new NonStrictExpectations() {{
+            statusLine.getStatusCode(); returns(401, 201);
+            authCommand.call(); result = new AccessTenant();
+        }};
+        this.account = new AccountImpl(authCommand, httpClient, defaultAccess, true, TempUrlHashPrefixSource.PUBLIC_URL_PATH, '/');
+        final String preferredRegion = "testPreferredRegion";
+        this.account.setPreferredRegion(preferredRegion);
+        new CreateContainerCommandImpl(this.account, httpClient, defaultAccess, account.getContainer("containerName")).call();
+        assertEquals(preferredRegion, ((AbstractAccess)this.account.getAccess()).getPreferredRegion());
     }
 
     @Test(expected = UnauthorizedException.class)


### PR DESCRIPTION
Currently when reauthenticating the configured preferred region is not set. This causes the default region to be used instead which causes failure. This is logged as issue https://github.com/javaswift/joss/issues/72. This fix is to remember the preferred region in the account and to use that value to set the preferred region on the access object used during reauthentication.
