### PR TITLE
Abort a download request before closing input stream

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/object/AbstractDownloadObjectCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/object/AbstractDownloadObjectCommand.java
@@ -25,6 +25,8 @@ public abstract class AbstractDownloadObjectCommand<M extends HttpGet, N> extend
     public static final String ETAG             = "ETag";
     public static final String CONTENT_LENGTH   = "Content-Length";
 
+    private HttpGet request;
+
     public AbstractDownloadObjectCommand(Account account, HttpClient httpClient, Access access,
                                          StoredObject object, DownloadInstructions downloadInstructions) {
         super(account, httpClient, access, object);
@@ -69,7 +71,8 @@ public abstract class AbstractDownloadObjectCommand<M extends HttpGet, N> extend
 
     @Override
     protected HttpGet createRequest(String url) {
-        return new HttpGet(url);
+        this.request = new HttpGet(url);
+        return this.request;
     }
 
     @Override
@@ -83,4 +86,11 @@ public abstract class AbstractDownloadObjectCommand<M extends HttpGet, N> extend
         };
     }
 
+    @Override
+    public void close() throws IOException {
+        if (this.request != null) {
+            this.request.abort();
+        }
+        super.close();
+    }
 }


### PR DESCRIPTION
This PR is a performance improvement when reading part of a large object.

Closing a download input stream when it has unread data, waits to consume the contents of the stream before resources are released. Aborting the get request first ensures that the close operation is instantaneous.

Please let me how it looks. Thanks.