### PR TITLE
added configuration flag if should synchronize time with server

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractClient.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractClient.java
@@ -40,7 +40,9 @@ public abstract class AbstractClient<A extends Account> implements Client<A> {
             accountConfig.setTenantName(tenant.name);
             account = createAccount();
         }
-        account.synchronizeWithServerTime();
+        if (accountConfig.isAllowSynchronizeWithServer()) {
+            account.synchronizeWithServerTime();
+        }
         return (A)account
                 .setPublicHost(accountConfig.getPublicHost())
                 .setPrivateHost(accountConfig.getPrivateHost())

--- a/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
@@ -30,6 +30,10 @@ public class AccountConfig {
     private String authUrl;
 
     /**
+     * if false, JOSS will not synchronize time with the server
+     */
+    private boolean allowSynchronizeWithServer = true;
+    /**
     * The hash for a TempURL is based on the object path which consists of the the pure path to an
     * object. Eg, /v1/AUTH_Account/Container/Object. The first part ("/v1/AUTH_Account") must be
     * derived from one of the URLs in an Endpoint. By default this is the Public URL. However, sometimes
@@ -395,4 +399,12 @@ public class AccountConfig {
     public void setMockClasspath(Class mockClasspath) {
         this.mockClasspath = mockClasspath;
     }
+
+	public boolean isAllowSynchronizeWithServer() {
+		return allowSynchronizeWithServer;
+	}
+
+	public void setAllowSynchronizeWithServer(boolean allowSynchronizeWithServer) {
+		this.allowSynchronizeWithServer = allowSynchronizeWithServer;
+	}
 }


### PR DESCRIPTION
AbstractClient always performs account.synchronizeWithServerTime();
JOSS does it by HEAD on the account.
However user may not have read ACL on the account, but only on the container.
In this case HEAD on account will respond with 401 Not Authorized.

This patch adds a flag that may disable synchronize with the server. In the future we may want to consider synchronize times by doing HEAD on container/object and not account)

AccountConfig will contain new entry
private boolean allowSynchronizeWithServer = true;
The default is true, so the existing functionality will remain the same

Setting this value to false, will disable account.synchronizeWithServerTime(); 
This will affect TempUrl, that depends on server time when setting expiry. When TempUrl is not used by flows calling account.synchronizeWithServerTime();  is useless and can produce issues when user doesn't has read ACL on the account