### PR TITLE
Do not change existing hash password

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
@@ -74,7 +74,7 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
     @Override
     public AbstractAccount setHashPassword(String hashPassword) {
         LOG.info("JOSS / Setting hash password");
-        if (hashPassword != null && !hashPassword.equals(getHashPassword())) {
+        if (hashPassword != null && (getHashPassword() == null || "".equals(getHashPassword()))) {
             LOG.info("JOSS / Hash password not yet saved, saving now");
             this.commandFactory.createHashPasswordCommand(this, hashPassword).call();
         }


### PR DESCRIPTION
The original code changes the hash password in the account in case a different password is given than was stored in the account. I can't see why that would be useful as the entire use of a password is then gone. I changed the code to check whether a hash password in the account  already exists. If it does NOT exist and we supply a new hash password, it is set to the given hash password.