### PR TITLE
Manually release HTTP connection in case of exception

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
@@ -50,11 +50,13 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
             HttpStatusChecker.verifyCode(getStatusCheckers(), response.getStatusLine().getStatusCode());
             return getReturnObject(response);
         } catch (CommandException err) {
+        	request.releaseConnection();
             if (allowErrorLog) { // This is disabled, for example, for exists(), where we want to ignore the exception
                 logError(request, err);
             }
             throw err;
         } catch (IOException err) {
+        	request.releaseConnection();
             throw new CommandException("Unable to execute the HTTP call or to convert the HTTP Response", err);
         } finally {
             if (closeStreamAutomatically()) {


### PR DESCRIPTION
It was found the incoming requests will be stuck after many Download/Upload requests throws exceptions. In those cases, the httpclient object can not be released automatically after investigation and need to be released manually.  Otherwise, all the subsequent requests will be hung after the connections in Connection Pool are consumed out.
The commit will manually release HTTP connection which be be returned back to Connection Pool if request runs into exception.
