### PR TITLE
To offer a chance to get response headers from once-off Download/Upload API call

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
@@ -1,5 +1,6 @@
 package org.javaswift.joss.client.core;
 
+import org.apache.http.Header;
 import org.javaswift.joss.command.shared.factory.StoredObjectCommandFactory;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.headers.Metadata;
@@ -26,6 +27,8 @@ public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<Obj
     private Container container;
 
     private final StoredObjectCommandFactory commandFactory;
+    
+    private Header[] responseHeaders;
 
     public AbstractStoredObject(Container container, String name, boolean allowCaching) {
         super(allowCaching);
@@ -291,6 +294,14 @@ public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<Obj
                 .setFixedExpiry(expiry)
                 .verify(signature, expiry);
     }
+    
+    public Header[] getResponseHeaders() {
+		return responseHeaders;
+	}
+
+	public void setResponseHeaders(Header[] responseHeaders) {
+		this.responseHeaders = responseHeaders;
+	}
 
     public boolean isObject() { return true; }
     public boolean isDirectory() { return false; }

--- a/src/main/java/org/javaswift/joss/command/impl/object/AbstractDownloadObjectCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/object/AbstractDownloadObjectCommand.java
@@ -49,6 +49,7 @@ public abstract class AbstractDownloadObjectCommand<M extends HttpGet, N> extend
         String expectedMd5 = response.getHeaders(ETAG)[0].getValue().replaceAll("\"", "");
         boolean isManifest = Header.headerNotEmpty(response, X_OBJECT_MANIFEST);
         handleEntity(response.getEntity());
+        populateResponseHeaders(response);
         if (    !isManifest &&  // Manifest files may not be checked
                 HttpStatus.SC_PARTIAL_CONTENT != response.getStatusLine().getStatusCode()) {
                                 // etag match on partial content makes no sense)

--- a/src/main/java/org/javaswift/joss/command/impl/object/AbstractObjectCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/object/AbstractObjectCommand.java
@@ -1,5 +1,8 @@
 package org.javaswift.joss.command.impl.object;
 
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.javaswift.joss.command.impl.core.AbstractSecureCommand;
@@ -9,8 +12,24 @@ import org.javaswift.joss.model.StoredObject;
 
 public abstract class AbstractObjectCommand<M extends HttpRequestBase, N> extends AbstractSecureCommand<M, N> {
 
+	private StoredObject object;
+	
     public AbstractObjectCommand(Account account, HttpClient httpClient, Access access, StoredObject object) {
         super(account, httpClient, getURL(access, object), access.getToken());
+        this.object = object;
+    }
+    
+    public StoredObject getStoredObject() {
+		return object;
+	}
+    
+    public void populateResponseHeaders(HttpResponse response) {
+		object.setResponseHeaders(response.getAllHeaders());
+	}
+    
+    protected N getReturnObject(HttpResponse response) throws IOException {
+		populateResponseHeaders(response);
+        return null; // returns null by default
     }
 
 }

--- a/src/main/java/org/javaswift/joss/model/StoredObject.java
+++ b/src/main/java/org/javaswift/joss/model/StoredObject.java
@@ -1,5 +1,6 @@
 package org.javaswift.joss.model;
 
+import org.apache.http.Header;
 import org.javaswift.joss.instructions.DownloadInstructions;
 import org.javaswift.joss.instructions.UploadInstructions;
 
@@ -266,5 +267,6 @@ public interface StoredObject extends ObjectStoreEntity, Comparable<DirectoryOrO
     void setEtag(String etag);
     void setContentLength(long contentLength);
     void setContentTypeWithoutSaving(String contentType);
-
+    void setResponseHeaders(Header[] headers);
+    Header[] getResponseHeaders();
 }


### PR DESCRIPTION
In order to reduce the API call times between Joss and back-end storage service, Joss should offer the chance to get all response headers from Object Download and Upload operation. E.g. Client wants to download an Object and get its 'Content-Length' header as well. That's easy to do with with just one time call of  Swift or Ceph Radosgw download API. However, Joss has to call Swift or Radosgw twice, one is GET and the other is HEAD. That's not so pretty in the case of high concurrency of requests.
The commit offers the chance  to Get/Put object and retrieve some headers from one time API call.