### PR TITLE
Set timezone to GMT in AbstractStoredObject.setLastModified()

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractStoredObject.java
@@ -16,6 +16,7 @@ import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<ObjectInformation> implements StoredObject {
 
@@ -116,6 +117,7 @@ public abstract class AbstractStoredObject extends AbstractObjectStoreEntity<Obj
         try {
             // The LastModified date in the JSON body differs from that in the response header
             SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+            formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
             setLastModified(formatter.parse(date));
         } catch (ParseException e) {
             throw new CommandException("Unable to convert date string: "+date, e);


### PR DESCRIPTION
In certain cases, when reading an object and AbstractStoredObject.setLastModified() is called the DateTimeFormatter defaults to the user's local timezone when parsing when it should default to GMT.