### PR TITLE
Issue#85 Complete proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to use JOSS in your project, simply add the following dependency:
         <dependency>
             <groupId>org.javaswift</groupId>
             <artifactId>joss</artifactId>
-            <version>0.9.15</version>
+            <version>0.10.0</version>
         </dependency>
 ```
 
@@ -120,6 +120,49 @@ Likewise, this information can be retrieved, as seen above.
     for (String name : returnedMetadata.keySet()) {
         System.out.println("META / "+name+": "+returnedMetadata.get(name));
     }
+```
+
+It is possible to connect with proxy, there are two options how to setup it:
+
+Option A: Programmatically
+
+```java
+    AccountConfig config = new AccountConfig()                                
+                            config.setUseProxy(true)
+                            config.setProxyHost("hostname")
+                            config.setProxyPort(3128);
+```
+
+Also you can specify username and password if authentication required:
+
+```java
+    AccountConfig config = new AccountConfig()
+    config.setProxyUsername("some-user")
+    config.setProxyPort("some-password");
+```
+
+Option B: JVM Proxy Settings
+
+- Edit `${JAVA_HOME}/jre/lib/net.properties`, set properties:
+
+```
+    java.net.useSystemProxies=true
+     
+    ...
+    http.proxyHost=some-host
+    http.proxyPort=some-port
+```
+
+or
+
+- Specify as JVM options: 
+
+```
+    -Djava.net.useSystemProxies=true 
+    -Dhttp.proxyHost=http://PROXY_HOST \
+    -Dhttp.proxyPort=PROXY_PORT \ 
+    -Dhttp.proxyUser=USERNAME \
+    -Dhttp.proxyPassword=PASSWORD
 ```
 
 There are many situations in which it is not necessary, not possible, or even plain clumsy, to be connected to external dependencies. For those situations, JOSS offers the InMemory implementation of the OpenStackClient.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.javaswift</groupId>
     <artifactId>joss</artifactId>
-    <version>0.9.15</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
     <name>Java OpenStack Storage</name>
     <description>Java Client library for OpenStack Storage (Swift)</description>
@@ -44,7 +44,7 @@
     <properties>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.3</commons.io.version>
-        <httpcomponents.version>4.2.1</httpcomponents.version>
+        <httpcomponents.version>4.5.3</httpcomponents.version>
         <jackson.version>1.9.7</jackson.version>
         <junit.version>4.10</junit.version>
         <mockit.version>1.6</mockit.version>

--- a/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
@@ -30,6 +30,31 @@ public class AccountConfig {
     private String authUrl;
 
     /**
+     * Use proxy
+     */
+    private boolean useProxy;
+
+    /**
+     * Proxy server (hostname\ip)
+     */
+    private String proxyHost;
+
+    /**
+     * Proxy port
+     */
+    private int proxyPort;
+
+    /**
+     * Proxy username
+     */
+    private String proxyUsername;
+
+    /**
+     * Proxy password
+     */
+    private String proxyPassword;
+
+    /**
      * if false, JOSS will not synchronize time with the server
      */
     private boolean allowSynchronizeWithServer = true;
@@ -400,7 +425,47 @@ public class AccountConfig {
         this.mockClasspath = mockClasspath;
     }
 
-	public boolean isAllowSynchronizeWithServer() {
+    public boolean isUseProxy() {
+        return useProxy;
+    }
+
+    public void setUseProxy(boolean useProxy) {
+        this.useProxy = useProxy;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(int proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    public void setProxyUsername(String proxyUsername) {
+        this.proxyUsername = proxyUsername;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
+    public boolean isAllowSynchronizeWithServer() {
 		return allowSynchronizeWithServer;
 	}
 

--- a/src/test/java/org/javaswift/joss/client/impl/ClientImplTest.java
+++ b/src/test/java/org/javaswift/joss/client/impl/ClientImplTest.java
@@ -4,9 +4,11 @@ import mockit.NonStrictExpectations;
 import org.apache.http.Header;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.javaswift.joss.client.factory.AccountConfig;
+import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.command.impl.core.BaseCommandTest;
 import org.javaswift.joss.model.Account;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.net.ssl.X509TrustManager;
@@ -114,6 +116,36 @@ public class ClientImplTest extends BaseCommandTest {
         config = new AccountConfig();
         config.setDisableSslValidation(true);
         new ClientImpl(config);
+    }
+
+    // INTEGRATION TEST
+    @Ignore
+    @Test
+    public void connectViaProxy() {
+        // Without proxy authorization
+
+        config.setAuthenticationMethod(AuthenticationMethod.BASIC);
+
+        config.setAuthUrl("https://openstack-swift-endpoint"); // CHANGE ME
+        config.setUsername("some-user"); // CHANGE ME
+        config.setPassword("some-password"); // CHANGE ME
+
+        config.setUseProxy(true);
+        config.setProxyHost("proxy-host"); // CHANGE ME
+        config.setProxyPort(3128); // CHANGE ME
+
+        ClientImpl client = new ClientImpl(config);
+
+        client.authenticate();
+
+        // With proxy authorization
+
+        config.setProxyUsername("some-user"); // CHANGE ME
+        config.setProxyPassword("some-password"); // CHANGE ME
+
+        client = new ClientImpl(config);
+
+        client.authenticate();
     }
 
 }

--- a/src/test/java/org/javaswift/joss/client/impl/ClientImplTest.java
+++ b/src/test/java/org/javaswift/joss/client/impl/ClientImplTest.java
@@ -116,15 +116,5 @@ public class ClientImplTest extends BaseCommandTest {
         new ClientImpl(config);
     }
 
-    @Test (expected = RuntimeException.class)
-    public void throwSecurityException() throws GeneralSecurityException {
-        final PoolingClientConnectionManager connectionManager = new PoolingClientConnectionManager();
-        new NonStrictExpectations(connectionManager) {{
-            connectionManager.getSchemeRegistry();
-            result = new GeneralSecurityException();
-        }};
-        client.disableSslValidation(connectionManager);
-    }
-
 }
 


### PR DESCRIPTION
Patch adds:

### Complete proxy support

**1. Programmatically way:**

```java
AccountConfig config = new AccountConfig()                                
                         config.setUseProxy(true)
                         config.setProxyHost("hostname")
                         config.setProxyPort(3128);
```

Also you can specify username and password if authentication required:

```java
AccountConfig config = new AccountConfig()
config.setProxyUsername("some-user")
config.setProxyPort("some-password");
```

**2. JVM `net.properties` way:**

Edit `${JAVA_HOME}/jre/lib/net.properties`:

```
java.net.useSystemProxies=true
     
 ...
http.proxyHost=some-host
http.proxyPort=some-port
```

**3. JVM startup options way:**
```
java -Djava.net.useSystemProxies=true \
       -Dhttp.proxyHost=http://PROXY_HOST \
       -Dhttp.proxyPort=PROXY_PORT 
       -Dhttp.proxyUser=USERNAME \
       -Dhttp.proxyPassword=PASSWORD 
       -jar your-app.jar
```

### Upgrade Apache HttpClient library

4.2.1 > 4.5.3

for support `useSystemProperties()`