### PR TITLE
Add last_modified field to ContainerListElement

### DIFF
--- a/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
+++ b/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
@@ -1,5 +1,7 @@
 package org.javaswift.joss.command.shared.account;
 
+import org.codehaus.jackson.annotate.JsonProperty;
+
 public class ContainerListElement {
 
     public String name;
@@ -8,4 +10,6 @@ public class ContainerListElement {
 
     public long bytes;
 
+    @JsonProperty(value="last_modified")
+    public String lastModified;    
 }

--- a/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
+++ b/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
@@ -11,5 +11,5 @@ public class ContainerListElement {
     public long bytes;
 
     @JsonProperty(value="last_modified")
-    public String lastModified;    
+    public String lastModified;
 }

--- a/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
@@ -22,6 +22,17 @@ public class ContainerListingTest {
     }
 
     @Test
+    public void testUnmarshallingSingleElementSwift2130() throws IOException {
+        String jsonString = new ClasspathTemplateResource("/sample-container-listing-swift2.13.0.json").loadTemplate();
+        ObjectMapper mapper = new ObjectMapper();
+        ContainerListElement listing = mapper.readValue(jsonString, ContainerListElement.class);
+        assertEquals("Amersfoort", listing.name);
+        assertEquals(48, listing.count);
+        assertEquals(1028296, listing.bytes);
+        assertEquals("2013-11-19T20:08:13.283452", listing.lastModified);
+    }
+
+    @Test
     public void testUnmarshallingList() throws IOException {
         String jsonString = new ClasspathTemplateResource("/sample-container-list.json").loadTemplate();
         ObjectMapper mapper = new ObjectMapper();

--- a/src/test/resources/sample-container-listing-swift2.13.0.json
+++ b/src/test/resources/sample-container-listing-swift2.13.0.json
@@ -1,0 +1,1 @@
+{"name":"Amersfoort","count":48,"bytes":1028296,"last_modified": "2013-11-19T20:08:13.283452"}


### PR DESCRIPTION
Fix issue #137 by adding last_modified field to ContainerListElement.

I was able to test the fix with Hubic which is running OpenStack 2.15.1.dev52.
