### PR TITLE
Stop leaking connection when status code verification throws exception

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
@@ -45,9 +45,11 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
 
     public N call() {
         logCall(request);
+        boolean statusCodeVerified = false;
         try {
             response = httpClient.execute(request);
             HttpStatusChecker.verifyCode(getStatusCheckers(), response.getStatusLine().getStatusCode());
+            statusCodeVerified = true;
             return getReturnObject(response);
         } catch (CommandException err) {
             if (allowErrorLog) { // This is disabled, for example, for exists(), where we want to ignore the exception
@@ -57,7 +59,7 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
         } catch (IOException err) {
             throw new CommandException("Unable to execute the HTTP call or to convert the HTTP Response", err);
         } finally {
-            if (closeStreamAutomatically()) {
+            if (closeStreamAutomatically() || !statusCodeVerified) {
                 try { close(); } catch (IOException err) { /* ignore */ }
             }
         }

--- a/src/test/java/org/javaswift/joss/command/impl/object/DownloadObjectAsInputStreamCommandImplTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/object/DownloadObjectAsInputStreamCommandImplTest.java
@@ -1,9 +1,11 @@
 package org.javaswift.joss.command.impl.object;
 
+import mockit.Verifications;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.util.EntityUtils;
 import org.javaswift.joss.command.impl.core.BaseCommandTest;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.instructions.DownloadInstructions;
@@ -60,5 +62,17 @@ public class DownloadObjectAsInputStreamCommandImplTest extends BaseCommandTest 
         prepareBytes(new byte[] { 0x01, 0x02, 0x03}, null);
         isSecure(new DownloadObjectAsInputStreamCommandImpl(this.account, httpClient, defaultAccess,
                 getObject("objectname"), new DownloadInstructions()));
+    }
+
+    @Test
+    public void entityClosedOnStatusCodeVerificationFailure() throws IOException {
+        final DownloadObjectAsInputStreamCommandImpl command = new DownloadObjectAsInputStreamCommandImpl(this.account, httpClient, defaultAccess, getObject("objectname"), new DownloadInstructions());
+        try {
+            checkForError(404, command);
+        } catch (CommandException err) {
+            new Verifications() {{
+                command.close(); times = 1;
+            }};
+        }
     }
 }


### PR DESCRIPTION
Per the apache documentation at https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html, one must consume the entity to avoid leaking a connection.  When attempting to execute a download command, the entity will not be automatically closed.  However, if the download command's status fails verification (ex: 404), then an exception is received by the client and the client does not have a chance to use the InputStream and close it.  This PR will close the entity if statusCodeVerification has failed.