### PR TITLE
- add bulk delete functionality

### DIFF
--- a/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
+++ b/src/main/java/org/javaswift/joss/client/core/AbstractAccount.java
@@ -1,6 +1,7 @@
 package org.javaswift.joss.client.core;
 
 import org.javaswift.joss.command.shared.factory.AccountCommandFactory;
+import org.javaswift.joss.command.shared.identity.bulkdelete.BulkDeleteResponse;
 import org.javaswift.joss.command.shared.identity.tenant.Tenants;
 import org.javaswift.joss.headers.Metadata;
 import org.javaswift.joss.headers.account.AccountMetadata;
@@ -242,6 +243,11 @@ public abstract class AbstractAccount extends AbstractObjectStoreEntity<AccountI
     @Override
     public String getOriginalHost() {
         return this.commandFactory.getOriginalHost();
+    }
+
+    @Override
+    public BulkDeleteResponse bulkDelete(Collection<ObjectIdentifier> objectsToDelete) {
+        return commandFactory.createBulkDeleteCommand(this, objectsToDelete).call();
     }
 
 }

--- a/src/main/java/org/javaswift/joss/command/impl/account/BulkDeleteCommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/account/BulkDeleteCommandImpl.java
@@ -1,0 +1,69 @@
+package org.javaswift.joss.command.impl.account;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.StringJoiner;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusRange;
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusSuccessCondition;
+import org.javaswift.joss.command.shared.account.BulkDeleteCommand;
+import org.javaswift.joss.command.shared.identity.bulkdelete.BulkDeleteResponse;
+import org.javaswift.joss.exception.CommandException;
+import org.javaswift.joss.headers.Accept;
+import org.javaswift.joss.instructions.QueryParameter;
+import org.javaswift.joss.instructions.QueryParameters;
+import org.javaswift.joss.model.Access;
+import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.ObjectIdentifier;
+
+public class BulkDeleteCommandImpl extends AbstractAccountCommand<HttpPost, BulkDeleteResponse>
+    implements BulkDeleteCommand {
+
+    private static final String BULK_DELETE_PARAMETER = "bulk-delete";
+
+    public BulkDeleteCommandImpl(Account account, HttpClient httpClient, Access access, Collection<ObjectIdentifier> objectsToDelete) {
+        super(account, httpClient, access);
+        modifyURI(getBulkDeleteQueryParameter());
+        setHeader(new Accept("application/json"));
+        setBulkDeleteContent(objectsToDelete);
+    }
+
+    @Override
+    protected HttpPost createRequest(String url) {
+        return new HttpPost(url);
+    }
+
+    @Override
+    public HttpStatusChecker[] getStatusCheckers() {
+        return new HttpStatusChecker[] {new HttpStatusSuccessCondition(new HttpStatusRange(200, 299))};
+    }
+
+    @Override
+    protected BulkDeleteResponse getReturnObject(HttpResponse response) throws IOException {
+        return createObjectMapper(false)
+            .readValue(response.getEntity().getContent(), BulkDeleteResponse.class);
+    }
+
+    private QueryParameters getBulkDeleteQueryParameter() {
+        return new QueryParameters(new QueryParameter[] {new QueryParameter(BULK_DELETE_PARAMETER, Boolean.TRUE
+            .toString())});
+    }
+
+    private void setBulkDeleteContent(Collection<ObjectIdentifier> objectsToDelete) {
+        try {
+            StringJoiner joiner = new StringJoiner("\n");
+            for (ObjectIdentifier object : objectsToDelete) {
+                joiner.add(object.getUrlEncodedIdentifier());
+            }
+            StringEntity input = new StringEntity(joiner.toString());
+            request.setEntity(input);
+        } catch (IOException err) {
+            throw new CommandException("Unable to set the text/plain body for the bulk-delete request", err);
+        }
+    }
+}

--- a/src/main/java/org/javaswift/joss/command/impl/factory/AccountCommandFactoryImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/factory/AccountCommandFactoryImpl.java
@@ -11,6 +11,7 @@ import org.javaswift.joss.headers.Header;
 import org.javaswift.joss.instructions.ListInstructions;
 import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.ObjectIdentifier;
 
 import java.util.Collection;
 
@@ -89,6 +90,11 @@ public class AccountCommandFactoryImpl implements AccountCommandFactory {
     @Override
     public HashPasswordCommand createHashPasswordCommand(Account account, String hashPassword) {
         return new HashPasswordCommandImpl(account, httpClient, access, hashPassword);
+    }
+
+    @Override
+    public BulkDeleteCommand createBulkDeleteCommand(Account account, Collection<ObjectIdentifier> objectsToDelete) {
+        return new BulkDeleteCommandImpl(account, httpClient, access, objectsToDelete);
     }
 
     @Override

--- a/src/main/java/org/javaswift/joss/command/mock/account/BulkDeleteCommandMock.java
+++ b/src/main/java/org/javaswift/joss/command/mock/account/BulkDeleteCommandMock.java
@@ -1,0 +1,36 @@
+package org.javaswift.joss.command.mock.account;
+
+import java.util.Collection;
+
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusRange;
+import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusSuccessCondition;
+import org.javaswift.joss.command.mock.core.CommandMock;
+import org.javaswift.joss.command.shared.account.BulkDeleteCommand;
+import org.javaswift.joss.command.shared.identity.bulkdelete.BulkDeleteResponse;
+import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.ObjectIdentifier;
+import org.javaswift.joss.swift.Swift;
+import org.javaswift.joss.swift.SwiftResult;
+
+public class BulkDeleteCommandMock extends CommandMock<BulkDeleteResponse> implements
+    BulkDeleteCommand {
+
+    private Collection<ObjectIdentifier> objectsToDelete;
+
+    public BulkDeleteCommandMock(Swift swift, Account account, Collection<ObjectIdentifier> objectsToDelete) {
+        super(swift, account);
+        this.objectsToDelete = objectsToDelete;
+    }
+
+    @Override
+    public SwiftResult<BulkDeleteResponse> callSwift() {
+        return swift.bulkDelete(this.objectsToDelete);
+    }
+
+    @Override
+    public HttpStatusChecker[] getStatusCheckers() {
+        return new HttpStatusChecker[] {new HttpStatusSuccessCondition(new HttpStatusRange(200, 299))};
+    }
+
+}

--- a/src/main/java/org/javaswift/joss/command/mock/factory/AccountCommandFactoryMock.java
+++ b/src/main/java/org/javaswift/joss/command/mock/factory/AccountCommandFactoryMock.java
@@ -8,6 +8,7 @@ import org.javaswift.joss.headers.Header;
 import org.javaswift.joss.instructions.ListInstructions;
 import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.ObjectIdentifier;
 import org.javaswift.joss.swift.Swift;
 
 import java.util.Collection;
@@ -81,6 +82,11 @@ public class AccountCommandFactoryMock implements AccountCommandFactory {
     @Override
     public HashPasswordCommand createHashPasswordCommand(Account account, String hashPassword) {
         return new HashPasswordCommandMock(swift, account, hashPassword);
+    }
+
+    @Override
+    public BulkDeleteCommand createBulkDeleteCommand(Account account, Collection<ObjectIdentifier> objectsToDelete) {
+        return new BulkDeleteCommandMock(swift, account, objectsToDelete);
     }
 
     @Override

--- a/src/main/java/org/javaswift/joss/command/shared/account/BulkDeleteCommand.java
+++ b/src/main/java/org/javaswift/joss/command/shared/account/BulkDeleteCommand.java
@@ -1,0 +1,7 @@
+package org.javaswift.joss.command.shared.account;
+
+import org.javaswift.joss.command.shared.core.Command;
+import org.javaswift.joss.command.shared.identity.bulkdelete.BulkDeleteResponse;
+
+public interface BulkDeleteCommand extends Command<BulkDeleteResponse> {
+}

--- a/src/main/java/org/javaswift/joss/command/shared/factory/AccountCommandFactory.java
+++ b/src/main/java/org/javaswift/joss/command/shared/factory/AccountCommandFactory.java
@@ -5,6 +5,7 @@ import org.javaswift.joss.headers.Header;
 import org.javaswift.joss.instructions.ListInstructions;
 import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
+import org.javaswift.joss.model.ObjectIdentifier;
 
 import java.util.Collection;
 
@@ -33,7 +34,9 @@ public interface AccountCommandFactory {
     TenantCommand createTenantCommand(Account account);
 
     HashPasswordCommand createHashPasswordCommand(Account account, String hashPassword);
-
+    
+    BulkDeleteCommand createBulkDeleteCommand(Account account, Collection<ObjectIdentifier> objectsToDelete);
+    
     ContainerCommandFactory getContainerCommandFactory();
 
     public boolean isTenantSupplied();

--- a/src/main/java/org/javaswift/joss/command/shared/identity/bulkdelete/BulkDeleteResponse.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/bulkdelete/BulkDeleteResponse.java
@@ -1,0 +1,17 @@
+package org.javaswift.joss.command.shared.identity.bulkdelete;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BulkDeleteResponse {
+
+    @JsonProperty("Number Deleted")
+    public long          numberDeleted;
+
+    @JsonProperty("Number Not Found")
+    public long          numberNotFound;
+
+    @JsonProperty("Errors")
+    public ErrorObject[] errors;
+}

--- a/src/main/java/org/javaswift/joss/command/shared/identity/bulkdelete/ErrorObject.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/bulkdelete/ErrorObject.java
@@ -1,0 +1,12 @@
+package org.javaswift.joss.command.shared.identity.bulkdelete;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorObject {
+
+    public String name;
+
+    public String status;
+
+}

--- a/src/main/java/org/javaswift/joss/model/Account.java
+++ b/src/main/java/org/javaswift/joss/model/Account.java
@@ -1,6 +1,9 @@
 package org.javaswift.joss.model;
 
+import org.javaswift.joss.command.shared.identity.bulkdelete.BulkDeleteResponse;
 import org.javaswift.joss.command.shared.identity.tenant.Tenants;
+
+import java.util.Collection;
 
 /**
  * Account is the root entity in Object Store. It allows you access to the various containers underneath. Note
@@ -194,4 +197,21 @@ public interface Account extends ObjectStoreEntity, ListHolder<Container> {
      * @return instance of Account
      */
     Account setPreferredRegion(String preferredRegion);
+
+    /**
+     * Deletes a list of objects or containers in a single operation. ObjectIdentifier may be both,
+     * an object or a container.
+     *
+     * Note: Make sure that the container is empty. If it contains objects, Object Storage cannot
+     * delete the container.
+     *
+     * The operation will only throw an exception, if the operation failed completely. To make sure
+     * all containers/objects were deleted successfully, have a look at the response object.
+     *
+     * @param objectsToDelete the objects to delete
+     * @return as the whole operation may complete successfully with some sub-operations having
+     *         failed, this response object contains the details, what was deleted and which errors
+     *         did occur
+     */
+    BulkDeleteResponse bulkDelete(Collection<ObjectIdentifier> objectsToDelete);
 }

--- a/src/main/java/org/javaswift/joss/model/ObjectIdentifier.java
+++ b/src/main/java/org/javaswift/joss/model/ObjectIdentifier.java
@@ -1,0 +1,38 @@
+package org.javaswift.joss.model;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+
+import org.javaswift.joss.util.SpaceURLEncoder;
+
+public class ObjectIdentifier {
+
+    private String containerName;
+    private String objectName;
+
+    public ObjectIdentifier(String containerName, String objectName) {
+        this.containerName = containerName;
+        this.objectName = objectName;
+    }
+
+    public ObjectIdentifier(String containerName) {
+        this(containerName, null);
+    }
+
+    public String getUrlEncodedIdentifier() throws UnsupportedEncodingException {
+        if (objectName == null) {
+            return SpaceURLEncoder.encode(containerName);
+        } else {
+            return SpaceURLEncoder.encode(containerName) + "/" + SpaceURLEncoder.encode(objectName);
+        }
+    }
+    
+    public String getContainerName() {
+        return containerName;
+    }
+    
+    public Optional<String> getObjectName() {
+        return Optional.ofNullable(objectName);
+    }
+
+}


### PR DESCRIPTION
Add bulk delete functionality to delete several objects / containers in one call.
-> implemented according to: https://docs.openstack.org/ocata/user-guide/cli-swift-bulk-delete.html

- use ObjectIdentifier to specify containers / objects
- deserialize result as BulkDeleteResponse
- extended Mock environment

---------------------------------------

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the Apache License 2.0; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

DCO 1.1 Signed-off-by: Thomas Ritscher