### PR TITLE
feat: Adds support for KeystoneV3 scoping during auth

### DIFF
--- a/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AccountConfig.java
@@ -215,7 +215,26 @@ public class AccountConfig {
      */
     private AuthenticationMethod authenticationMethod = KEYSTONE;
     
-    private AuthenticationMethod.AccessProvider accessProvider = null ;
+    private AuthenticationMethod.AccessProvider accessProvider = null;
+
+    /**
+     * Sets the scope of authentication when using the {@link AuthenticationMethod} Keystone V3.
+     * During authentication you can request a scope against a certain domain or project. Which might be required by
+     * your Keystone installation.
+     * <ul>
+     *     <li>
+     *         <b>DEFAULT</b>; Default authentication with no special scope. This is also the default setting.
+     *     </li>
+     *     <li>
+     *         <b>PROJECT_NAME</b>; Scopes against a tenant/project name. You must also provide the TenantName.
+     *     </li>
+     *     <li>
+     *         <b>DOMAIN_NAME</b>; Scopes against a domain name. You must also provide the Domain.
+     *     </li>
+     *
+     * </ul>
+     */
+    private AuthenticationMethodScope authenticationMethodScope = AuthenticationMethodScope.DEFAULT;
 
     /**
      * Keystone domain.  Used by the V3 Identity API
@@ -484,5 +503,11 @@ public class AccountConfig {
 
     public void setDomain(String domain) {
         this.domain = domain;
+    }
+
+    public AuthenticationMethodScope getAuthenticationMethodScope() { return authenticationMethodScope; }
+
+    public void setAuthenticationMethodScope(AuthenticationMethodScope scope) {
+        this.authenticationMethodScope = scope;
     }
 }

--- a/src/main/java/org/javaswift/joss/client/factory/AccountFactory.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AccountFactory.java
@@ -163,4 +163,9 @@ public class AccountFactory {
         this.config.setDomain(domain);
         return this;
     }
+
+    public AccountFactory setAuthenticationMode(AuthenticationMethodScope scope) {
+        this.config.setAuthenticationMethodScope(scope);
+        return this;
+    }
 }

--- a/src/main/java/org/javaswift/joss/client/factory/AuthenticationMethodScope.java
+++ b/src/main/java/org/javaswift/joss/client/factory/AuthenticationMethodScope.java
@@ -1,0 +1,20 @@
+package org.javaswift.joss.client.factory;
+
+/**
+ * The Keystone V3 API allows scoped authentication. By utilizing this option you can request a special scope during
+ * authentication.
+ *
+ * Depending on the chosen AuthenticationMethodScope different options must be provided in the {@link AccountConfig}
+ * object:
+ *
+ * <p>PROJECT_NAME: TenantName and Domain must be provided.</p>
+ * <p>DOMAIN_NAME: Domain must be provided.</p>
+ *
+ * <b>Note:</b> Currently only project/tenant name and domain name are supported. Scoping to the project/tenant ID or
+ * domain ID is not implemented.
+ */
+public enum AuthenticationMethodScope {
+    DEFAULT,
+    PROJECT_NAME,
+    DOMAIN_NAME
+}

--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
@@ -7,6 +7,7 @@ import org.apache.http.util.EntityUtils;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.headers.Header;
@@ -137,6 +138,7 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
         if (dealWithRootValue) {
             objectMapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
             objectMapper.configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);
+            objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
         }
         return objectMapper;
     }

--- a/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
@@ -14,7 +14,7 @@ import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusRange;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusSuccessCondition;
 import org.javaswift.joss.command.shared.identity.AuthenticationCommand;
 import org.javaswift.joss.command.shared.identity.access.KeystoneV3Access;
-import org.javaswift.joss.command.shared.identity.authentication.KeystoneV3Authentication;
+import org.javaswift.joss.command.shared.identity.authentication.*;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.headers.Accept;
 import org.javaswift.joss.model.Access;
@@ -35,16 +35,60 @@ public class KeystoneAuthenticationV3CommandImpl extends AbstractCommand<HttpPos
         this.responseMapper = createObjectMapper(false);
 
         setHeader(new Accept(ContentType.APPLICATION_JSON.getMimeType()));
-        setRequestBody(config.getUsername(), config.getPassword(), config.getDomain());
+
+        KeystoneV3Authentication auth = null;
+        switch (config.getAuthenticationMethodScope()) {
+            case DOMAIN_NAME:
+                auth = createKeystoneV3AuthenticationDomainScope(
+                        config.getUsername(),
+                        config.getPassword(),
+                        config.getDomain()
+                );
+                break;
+            case PROJECT_NAME:
+                createKeystoneV3AuthenticationProjectScope(
+                        config.getUsername(),
+                        config.getPassword(),
+                        config.getDomain(),
+                        config.getTenantName()
+                );
+                break;
+            default:
+                auth = createKeystoneV3AuthenticationDefaultScope(
+                        config.getUsername(),
+                        config.getPassword(),
+                        config.getDomain()
+                );
+                break;
+        }
+        setRequestBody(auth);
     }
 
-    private void setRequestBody(String username, String password, String domain) {
+    private KeystoneV3Authentication createKeystoneV3AuthenticationDefaultScope(String username, String password, String domain) {
+        KeystoneV3Authentication auth = new KeystoneV3Authentication();
+        auth.setIdentity(new KeystoneV3Identity(username, password, domain));
+        return auth;
+    }
+
+    private KeystoneV3Authentication createKeystoneV3AuthenticationProjectScope(String username, String password, String domain, String project) {
+        KeystoneV3Authentication auth = new KeystoneV3Authentication();
+        auth.setIdentity(new KeystoneV3Identity(username, password, domain));
+        auth.setScope(new KeystoneV3ProjectScope(project, new KeystoneV3Domain(domain)));
+        return auth;
+    }
+
+    private KeystoneV3Authentication createKeystoneV3AuthenticationDomainScope(String username, String password, String domain) {
+        KeystoneV3Authentication auth = new KeystoneV3Authentication();
+        auth.setIdentity(new KeystoneV3Identity(username, password, domain));
+        auth.setScope(new KeystoneV3DomainScope(new KeystoneV3Domain(domain)));
+        return auth;
+    }
+
+    private void setRequestBody(KeystoneV3Authentication auth) {
         try {
-            String jsonString = requestMapper.writeValueAsString(
-                new KeystoneV3Authentication(username, password, domain)
-            );
+            String jsonString = requestMapper.writeValueAsString(auth);
             request.setEntity(
-                new StringEntity(jsonString, ContentType.APPLICATION_JSON)
+                    new StringEntity(jsonString, ContentType.APPLICATION_JSON)
             );
         } catch (IOException ex) {
             throw new CommandException("Unable to set the JSON body on the request", ex);
@@ -67,8 +111,8 @@ public class KeystoneAuthenticationV3CommandImpl extends AbstractCommand<HttpPos
 
     @Override
     public HttpStatusChecker[] getStatusCheckers() {
-        return new HttpStatusChecker[] {
-            new HttpStatusSuccessCondition(new HttpStatusRange(200, 299))
+        return new HttpStatusChecker[]{
+                new HttpStatusSuccessCondition(new HttpStatusRange(200, 299))
         };
     }
 

--- a/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
@@ -46,7 +46,7 @@ public class KeystoneAuthenticationV3CommandImpl extends AbstractCommand<HttpPos
                 );
                 break;
             case PROJECT_NAME:
-                createKeystoneV3AuthenticationProjectScope(
+                auth = createKeystoneV3AuthenticationProjectScope(
                         config.getUsername(),
                         config.getPassword(),
                         config.getDomain(),

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Authentication.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Authentication.java
@@ -6,10 +6,13 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 public class KeystoneV3Authentication {
 
     private KeystoneV3Identity identity;
+    private KeystoneV3Scope scope;
 
-    public KeystoneV3Authentication(String username, String password, String domain) {
-        this.identity = new KeystoneV3Identity(username, password, domain);
-    }
+    public void setScope(KeystoneV3Scope scope) { this.scope = scope; }
+
+    public KeystoneV3Scope getScope() { return scope; }
+
+    public void setIdentity(KeystoneV3Identity identity) { this.identity = identity; }
 
     public KeystoneV3Identity getIdentity() {
         return identity;

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3DomainScope.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3DomainScope.java
@@ -1,0 +1,14 @@
+package org.javaswift.joss.command.shared.identity.authentication;
+
+public class KeystoneV3DomainScope implements KeystoneV3Scope {
+
+    private final KeystoneV3Domain domain;
+
+    public KeystoneV3DomainScope(KeystoneV3Domain domain) {
+        this.domain = domain;
+    }
+
+    public KeystoneV3Domain getDomain() {
+        return domain;
+    }
+}

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3ProjectScope.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3ProjectScope.java
@@ -1,0 +1,32 @@
+package org.javaswift.joss.command.shared.identity.authentication;
+
+public class KeystoneV3ProjectScope implements KeystoneV3Scope {
+
+    public static class KeystoneV3ProjectWrapped {
+        private final String name;
+        private final KeystoneV3Domain domain;
+
+        private KeystoneV3ProjectWrapped(String name, KeystoneV3Domain domain) {
+            this.name = name;
+            this.domain = domain;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public KeystoneV3Domain getDomain() {
+            return domain;
+        }
+    }
+
+    private KeystoneV3ProjectWrapped project;
+
+    public KeystoneV3ProjectScope(String name, KeystoneV3Domain domain) {
+        this.project = new KeystoneV3ProjectWrapped(name, domain);
+    }
+
+    public KeystoneV3ProjectWrapped getProject() {
+        return project;
+    }
+}

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3ProjectScope.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3ProjectScope.java
@@ -2,6 +2,8 @@ package org.javaswift.joss.command.shared.identity.authentication;
 
 public class KeystoneV3ProjectScope implements KeystoneV3Scope {
 
+    private KeystoneV3ProjectWrapped project;
+
     public static class KeystoneV3ProjectWrapped {
         private final String name;
         private final KeystoneV3Domain domain;
@@ -19,8 +21,6 @@ public class KeystoneV3ProjectScope implements KeystoneV3Scope {
             return domain;
         }
     }
-
-    private KeystoneV3ProjectWrapped project;
 
     public KeystoneV3ProjectScope(String name, KeystoneV3Domain domain) {
         this.project = new KeystoneV3ProjectWrapped(name, domain);

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Scope.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Scope.java
@@ -1,0 +1,4 @@
+package org.javaswift.joss.command.shared.identity.authentication;
+
+public interface KeystoneV3Scope {
+}

--- a/src/test/java/org/javaswift/joss/client/factory/AccountConfigTest.java
+++ b/src/test/java/org/javaswift/joss/client/factory/AccountConfigTest.java
@@ -33,6 +33,7 @@ public class AccountConfigTest {
         config.setPreferredRegion("AMS-01");
         config.setDisableSslValidation(true);
         config.setDelimiter('\\');
+        config.setAuthenticationMethodScope(AuthenticationMethodScope.DOMAIN_NAME);
         assertEquals("auth", config.getAuthUrl());
         assertEquals("pwd", config.getPassword());
         assertEquals("tenant", config.getTenantName());
@@ -56,5 +57,6 @@ public class AccountConfigTest {
         assertEquals("AMS-01", config.getPreferredRegion());
         assertEquals(true, config.isDisableSslValidation());
         assertEquals((Character)'\\', config.getDelimiter());
+        assertEquals(AuthenticationMethodScope.DOMAIN_NAME, config.getAuthenticationMethodScope());
     }
 }

--- a/src/test/java/org/javaswift/joss/client/factory/AccountFactoryTest.java
+++ b/src/test/java/org/javaswift/joss/client/factory/AccountFactoryTest.java
@@ -71,7 +71,8 @@ public class AccountFactoryTest {
                 .setTenantName(null)
                 .setTenantId(null)
                 .setUsername(null)
-                .setDelimiter('\\');
+                .setDelimiter('\\')
+                .setAuthenticationMethod(null);
     }
 
 }

--- a/src/test/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3AuthenticationTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3AuthenticationTest.java
@@ -3,6 +3,7 @@ package org.javaswift.joss.command.shared.identity.authentication;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -12,18 +13,54 @@ import static org.junit.Assert.assertEquals;
 public class KeystoneV3AuthenticationTest {
 
     @Test
-    public void testMarshalling() throws IOException {
+    public void testMarshallingDefaultScope() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
 
-        KeystoneV3Authentication authentication = new KeystoneV3Authentication(
-            "username",
-            "password",
-            "domainName"
-        );
+        KeystoneV3Authentication authentication = new KeystoneV3Authentication();
+        authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));
 
         JsonNode expectedContent = mapper.readTree(
             getClass().getResourceAsStream("/sample-v3-auth-request.json")
+        );
+
+        JsonNode actualContent = mapper.valueToTree(authentication);
+
+        assertEquals(expectedContent, actualContent);
+    }
+
+    @Test
+    public void testMarshallingDomainScope() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+
+        KeystoneV3Authentication authentication = new KeystoneV3Authentication();
+        authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));
+        authentication.setScope(new KeystoneV3DomainScope(new KeystoneV3Domain("domainName")));
+
+        JsonNode expectedContent = mapper.readTree(
+                getClass().getResourceAsStream("/sample-v3-auth-scope-domain-request.json")
+        );
+
+        JsonNode actualContent = mapper.valueToTree(authentication);
+
+        assertEquals(expectedContent, actualContent);
+    }
+
+    @Test
+    public void testMarshallingProjectScope() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+
+        KeystoneV3Authentication authentication = new KeystoneV3Authentication();
+        authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));
+        authentication.setScope(new KeystoneV3ProjectScope("projectName", new KeystoneV3Domain("domainName")));
+
+        JsonNode expectedContent = mapper.readTree(
+                getClass().getResourceAsStream("/sample-v3-auth-scope-project-request.json")
         );
 
         JsonNode actualContent = mapper.valueToTree(authentication);

--- a/src/test/resources/sample-v3-auth-scope-domain-request.json
+++ b/src/test/resources/sample-v3-auth-scope-domain-request.json
@@ -1,0 +1,23 @@
+{
+  "auth": {
+    "identity": {
+      "methods": [
+        "password"
+      ],
+      "password": {
+        "user": {
+          "name": "username",
+          "password": "password",
+          "domain": {
+            "name": "domainName"
+          }
+        }
+      }
+    },
+    "scope":{
+      "domain":{
+        "name":"domainName"
+      }
+    }
+  }
+}

--- a/src/test/resources/sample-v3-auth-scope-project-request.json
+++ b/src/test/resources/sample-v3-auth-scope-project-request.json
@@ -1,0 +1,26 @@
+{
+  "auth": {
+    "identity": {
+      "methods": [
+        "password"
+      ],
+      "password": {
+        "user": {
+          "name": "username",
+          "password": "password",
+          "domain": {
+            "name": "domainName"
+          }
+        }
+      }
+    },
+    "scope":{
+      "project":{
+        "name":"projectName",
+        "domain":{
+          "name":"domainName"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enables scoping against domain name as well as project name during authorization
with KeystoneV3.

This is the PR mentioned in ticket #155 .

Its maybe advisable to put the creation of the KeystoneV3Authentication objects into a dedicated Factory instead of doing it in the CommandImpl. But here I need feedback from the maintainers.