### PR TITLE
Ignore case when getting response headers with prefix

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/Header.java
+++ b/src/main/java/org/javaswift/joss/headers/Header.java
@@ -36,7 +36,7 @@ public abstract class Header {
     public static List<org.apache.http.Header> getResponseHeadersStartingWith(HttpResponse response, String prefix) {
         List<org.apache.http.Header> headers = new ArrayList<org.apache.http.Header>();
         for (org.apache.http.Header header : response.getAllHeaders()) {
-            if (header.getName().startsWith(prefix)) {
+            if (header.getName().toLowerCase().startsWith(prefix.toLowerCase())) {
                 headers.add(header);
             }
         }


### PR DESCRIPTION
HTTP header names should be [case insensitive according to RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)