### PR TITLE
HTTP Headers are case-insensitive

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/Header.java
+++ b/src/main/java/org/javaswift/joss/headers/Header.java
@@ -36,7 +36,7 @@ public abstract class Header {
     public static List<org.apache.http.Header> getResponseHeadersStartingWith(HttpResponse response, String prefix) {
         List<org.apache.http.Header> headers = new ArrayList<org.apache.http.Header>();
         for (org.apache.http.Header header : response.getAllHeaders()) {
-            if (header.getName().startsWith(prefix)) {
+            if (header.getName().toLowerCase().startsWith(prefix.toLowerCase())) {
                 headers.add(header);
             }
         }


### PR DESCRIPTION
HTTP Headers are case-insensitive. My provider or my HTTP library returned the headers as all-lowercase and therefore the Object headers were not returned correctly.

According to the official HTTP specs, HTTP headers should be case insensitive. I suggest we implement that here as well.