### PR TITLE
constructor args for AbstractRange subclasses: int to long

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/object/range/ExcludeStartRange.java
+++ b/src/main/java/org/javaswift/joss/headers/object/range/ExcludeStartRange.java
@@ -5,7 +5,7 @@ package org.javaswift.joss.headers.object.range;
  */
 public class ExcludeStartRange extends AbstractRange {
 
-    public ExcludeStartRange(int offset) {
+    public ExcludeStartRange(long offset) {
         super(offset, -1);
     }
 

--- a/src/main/java/org/javaswift/joss/headers/object/range/FirstPartRange.java
+++ b/src/main/java/org/javaswift/joss/headers/object/range/FirstPartRange.java
@@ -4,7 +4,7 @@ package org.javaswift.joss.headers.object.range;
  * Take the first bytes of the object until -- ie not including -- position 'until'
  */
 public class FirstPartRange extends AbstractRange {
-    public FirstPartRange(int until) {
+    public FirstPartRange(long until) {
         super(0, until);
     }
 

--- a/src/main/java/org/javaswift/joss/headers/object/range/LastPartRange.java
+++ b/src/main/java/org/javaswift/joss/headers/object/range/LastPartRange.java
@@ -5,7 +5,7 @@ package org.javaswift.joss.headers.object.range;
  */
 public class LastPartRange extends AbstractRange {
 
-    public LastPartRange(int lastBytes) {
+    public LastPartRange(long lastBytes) {
         super(-1, lastBytes);
     }
 

--- a/src/main/java/org/javaswift/joss/headers/object/range/MidPartRange.java
+++ b/src/main/java/org/javaswift/joss/headers/object/range/MidPartRange.java
@@ -5,7 +5,7 @@ package org.javaswift.joss.headers.object.range;
  */
 public class MidPartRange extends AbstractRange {
 
-    public MidPartRange(int startPos, int endPos) {
+    public MidPartRange(long startPos, long endPos) {
         super(startPos, endPos);
     }
 


### PR DESCRIPTION
This allows for HTTP range requests to use long for byte offset/position/length values so they will work with large files.