### PR TITLE
Bump jackson from 1.x to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- [#183](https://github.com/javaswift/joss/pull/183): Bump jackson from 1.x to 2.x, target JDK from 1.6 to 1.8 [@didot](https://github.com/didot) [#175](https://github.com/javaswift/joss/issues/175()
+- [#185](https://github.com/javaswift/joss/pull/185): Bump jackson from 1.x to 2.x, target JDK from 1.6 to 1.8 [@didot](https://github.com/didot) [#175](https://github.com/javaswift/joss/issues/175)
 
 ## [0.10.3](https://github.com/javaswift/joss/releases/tag/v0.10.3) - 2019-05-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- [#183](https://github.com/javaswift/joss/pull/183): Bump jackson from 1.x to 2.x, target JDK from 1.6 to 1.8 [@didot](https://github.com/didot) [#175](https://github.com/javaswift/joss/issues/175()
+
 ## [0.10.3](https://github.com/javaswift/joss/releases/tag/v0.10.3) - 2019-05-20
 ### Changed
 - [#156](https://github.com/javaswift/joss/pull/156): Adds support for KeystoneV3 scoping during auth [@tfelix](https://github.com/tfelix) [#155](https://github.com/javaswift/joss/issues/155)  

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.3</commons.io.version>
         <httpcomponents.version>4.5.3</httpcomponents.version>
-        <jackson.version>1.9.7</jackson.version>
+        <jackson.version>2.11.3</jackson.version>
         <junit.version>4.10</junit.version>
         <mockit.version>1.6</mockit.version>
         <slf4j.version>1.7.2</slf4j.version>
@@ -62,8 +62,8 @@
 
         <!-- Used for marshalling to / unmarshalling from JSON -->
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
@@ -147,8 +147,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
+++ b/src/main/java/org/javaswift/joss/command/impl/core/AbstractCommand.java
@@ -8,14 +8,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.util.EntityUtils;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.headers.Header;
@@ -136,9 +136,9 @@ public abstract class AbstractCommand<M extends HttpRequestBase, N> implements C
     protected ObjectMapper createObjectMapper(boolean dealWithRootValue) {
         ObjectMapper objectMapper = new ObjectMapper();
         if (dealWithRootValue) {
-            objectMapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
-            objectMapper.configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);
-            objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+            objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+            objectMapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
+            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }
         return objectMapper;
     }

--- a/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/KeystoneAuthenticationV3CommandImpl.java
@@ -2,13 +2,13 @@ package org.javaswift.joss.command.impl.identity;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.javaswift.joss.client.factory.AccountConfig;
 import org.javaswift.joss.command.impl.core.AbstractCommand;
 import org.javaswift.joss.command.impl.core.httpstatus.HttpStatusChecker;

--- a/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
+++ b/src/main/java/org/javaswift/joss/command/shared/account/ContainerListElement.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.account;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ContainerListElement {
 

--- a/src/main/java/org/javaswift/joss/command/shared/container/StoredObjectListElement.java
+++ b/src/main/java/org/javaswift/joss/command/shared/container/StoredObjectListElement.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.container;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StoredObjectListElement {
 

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessNoTenant.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessNoTenant.java
@@ -1,7 +1,7 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.annotate.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 
 @JsonRootName(value="access")

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessTenant.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/AccessTenant.java
@@ -3,10 +3,10 @@ package org.javaswift.joss.command.shared.identity.access;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import org.apache.http.HttpStatus;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 import org.javaswift.joss.exception.CommandExceptionError;
 import org.javaswift.joss.exception.HttpStatusExceptionUtil;

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/EndPoint.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/EndPoint.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EndPoint {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/KeystoneV3Access.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/KeystoneV3Access.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 import org.javaswift.joss.model.Access;
 

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/Metadata.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/Metadata.java
@@ -1,8 +1,8 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Metadata {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/Role.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/Role.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Role {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/ServiceCatalog.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/ServiceCatalog.java
@@ -1,9 +1,9 @@
 package org.javaswift.joss.command.shared.identity.access;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceCatalog {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/Tenant.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/Tenant.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Tenant {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/Token.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/Token.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.access;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Token {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/access/User.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/access/User.java
@@ -1,9 +1,9 @@
 package org.javaswift.joss.command.shared.identity.access;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class User {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/Authentication.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/Authentication.java
@@ -1,8 +1,7 @@
 package org.javaswift.joss.command.shared.identity.authentication;
 
-import org.codehaus.jackson.map.annotate.JsonRootName;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value="auth")
 public class Authentication {
@@ -16,12 +15,12 @@ public class Authentication {
         this.tenantId = tenantId;
     }
 
-    @JsonSerialize(include=Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getTenantId() {
         return this.tenantId;
     }
 
-    @JsonSerialize(include=Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getTenantName() {
         return this.tenantName;
     }

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Authentication.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3Authentication.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.authentication;
 
-import org.codehaus.jackson.map.annotate.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 @JsonRootName(value="auth")
 public class KeystoneV3Authentication {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3PasswordIdentity.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3PasswordIdentity.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.authentication;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class KeystoneV3PasswordIdentity {
 

--- a/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenant.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenant.java
@@ -1,6 +1,6 @@
 package org.javaswift.joss.command.shared.identity.tenant;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Tenant {

--- a/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenants.java
+++ b/src/main/java/org/javaswift/joss/command/shared/identity/tenant/Tenants.java
@@ -3,8 +3,8 @@ package org.javaswift.joss.command.shared.identity.tenant;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.javaswift.joss.exception.CommandException;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
+++ b/src/test/java/org/javaswift/joss/command/impl/account/ContainerListingTest.java
@@ -4,7 +4,7 @@ import static junit.framework.Assert.assertEquals;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javaswift.joss.command.shared.account.ContainerListElement;
 import org.javaswift.joss.util.ClasspathTemplateResource;
 import org.junit.Test;

--- a/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/access/AccessTest.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javaswift.joss.client.factory.TempUrlHashPrefixSource;
 import org.javaswift.joss.exception.CommandExceptionError;
 import org.javaswift.joss.exception.NotFoundException;
@@ -23,7 +23,7 @@ public class AccessTest {
     public void testUnmarshalling() throws IOException {
         String jsonString = new ClasspathTemplateResource("/sample-access.json").loadTemplate();
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);
+        mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
         Access access = mapper.readValue(jsonString, AccessTenant.class);
         assertEquals("a376b74fbdb64a4986cd3234647ff6f8", access.getToken());
         assertEquals("https://og.cloudvps.com:443/v1/AUTH_bfo000024", access.getInternalURL());

--- a/src/test/java/org/javaswift/joss/command/shared/identity/access/KeystoneV3AccessTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/access/KeystoneV3AccessTest.java
@@ -2,8 +2,8 @@ package org.javaswift.joss.command.shared.identity.access;
 
 import static org.junit.Assert.assertEquals;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/javaswift/joss/command/shared/identity/authentication/AuthenticationTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/authentication/AuthenticationTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
 public class AuthenticationTest {
@@ -13,7 +13,7 @@ public class AuthenticationTest {
     @Test
     public void testMarshalling() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
         Authentication auth = new Authentication("testtenant", "testtenantid", "testuser", "testpassword");
         assertEquals("{\"auth\":{\"passwordCredentials\":{\"username\":\"testuser\",\"password\":\"testpassword\"},\"tenantName\":\"testtenant\",\"tenantId\":\"testtenantid\"}}", mapper.writeValueAsString(auth));
     }

--- a/src/test/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3AuthenticationTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/authentication/KeystoneV3AuthenticationTest.java
@@ -4,10 +4,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
 public class KeystoneV3AuthenticationTest {
@@ -15,8 +15,8 @@ public class KeystoneV3AuthenticationTest {
     @Test
     public void testMarshallingDefaultScope() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
-        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         KeystoneV3Authentication authentication = new KeystoneV3Authentication();
         authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));
@@ -33,8 +33,8 @@ public class KeystoneV3AuthenticationTest {
     @Test
     public void testMarshallingDomainScope() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
-        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         KeystoneV3Authentication authentication = new KeystoneV3Authentication();
         authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));
@@ -52,8 +52,8 @@ public class KeystoneV3AuthenticationTest {
     @Test
     public void testMarshallingProjectScope() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationConfig.Feature.WRAP_ROOT_VALUE, true);
-        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         KeystoneV3Authentication authentication = new KeystoneV3Authentication();
         authentication.setIdentity(new KeystoneV3Identity("username", "password", "domainName"));

--- a/src/test/java/org/javaswift/joss/command/shared/identity/tenant/TenantsTest.java
+++ b/src/test/java/org/javaswift/joss/command/shared/identity/tenant/TenantsTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javaswift.joss.exception.CommandException;
 import org.junit.Test;
 


### PR DESCRIPTION
- Bump jackson from 1.x to 2.x: [notes](http://www.cowtowncoder.com/blog/archives/2012/04/entry_469.html), [changelog](https://github.com/FasterXML/jackson-core/blob/master/release-notes/VERSION-2.x)
- Bump target JDK from 1.6 to 1.8