### PR TITLE
fix to make metadata header prefix matching case-insensitive

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/Header.java
+++ b/src/main/java/org/javaswift/joss/headers/Header.java
@@ -35,8 +35,10 @@ public abstract class Header {
 
     public static List<org.apache.http.Header> getResponseHeadersStartingWith(HttpResponse response, String prefix) {
         List<org.apache.http.Header> headers = new ArrayList<org.apache.http.Header>();
+        String lowerPrefix = prefix.toLowerCase();
         for (org.apache.http.Header header : response.getAllHeaders()) {
-            if (header.getName().startsWith(prefix)) {
+            String hdr = header.getName().toLowerCase();
+            if (hdr.startsWith(lowerPrefix)) {
                 headers.add(header);
             }
         }


### PR DESCRIPTION
Container and object metadata headers (X-Container-Meta-{name} and X-Object-Meta-{name}) should be compared in a case-insensitive manner. This change fixes the prefix matching static method that finds such headers.

Many web front ends (eg HAProxy load balancer) santise http headers to lower case (presumably in preparation for HTTP/2).

