### PR TITLE
fix order of tenantName and username

### DIFF
--- a/src/main/java/org/javaswift/joss/command/impl/identity/BasicAuthenticationCommandImpl.java
+++ b/src/main/java/org/javaswift/joss/command/impl/identity/BasicAuthenticationCommandImpl.java
@@ -13,4 +13,8 @@ public class BasicAuthenticationCommandImpl extends AbstractSimpleAuthentication
         setHeader(new XAuthKey(password));
     }
 
+    @Override
+    protected String determineCompoundUsername(String username, String tenantName) {
+        return tenantName == null ? username : tenantName + ":" + username;
+    }
 }


### PR DESCRIPTION
when configuring the account, username and tenantName must be flipped