### PR TITLE
Case Sensitive Headers Matching

### DIFF
--- a/src/main/java/org/javaswift/joss/headers/Header.java
+++ b/src/main/java/org/javaswift/joss/headers/Header.java
@@ -35,8 +35,11 @@ public abstract class Header {
 
     public static List<org.apache.http.Header> getResponseHeadersStartingWith(HttpResponse response, String prefix) {
         List<org.apache.http.Header> headers = new ArrayList<org.apache.http.Header>();
+        if (prefix == null){
+            return headers;
+        }
         for (org.apache.http.Header header : response.getAllHeaders()) {
-            if (header.getName().startsWith(prefix)) {
+            if (header.getName().toLowerCase().startsWith(prefix.toLowerCase())) {
                 headers.add(header);
             }
         }

--- a/src/test/java/org/javaswift/joss/headers/HeaderTest.java
+++ b/src/test/java/org/javaswift/joss/headers/HeaderTest.java
@@ -8,7 +8,10 @@ import mockit.Mocked;
 import mockit.NonStrictExpectations;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
 import org.junit.Test;
+
+import java.util.List;
 
 public class HeaderTest {
 
@@ -44,4 +47,57 @@ public class HeaderTest {
         assertEquals("alpha", Header.convertResponseHeader(response, headerName));
     }
 
+    @Test
+    public void getHeadersWithHeaderNameMatchingPrefixCase() {
+
+        String headerValue = "34567as7dta8asd7";
+        String headerName = "x-account-meta-temp-url-key";
+        String searchString = "x-account-meta-";
+        final org.apache.http.Header myHeader = new BasicHeader(headerName, headerValue);
+
+        new Expectations() {{
+            response.getAllHeaders();
+            result = new org.apache.http.Header[]{myHeader};
+        }};
+        List<org.apache.http.Header> matchedHeaders = Header.getResponseHeadersStartingWith(
+                response,
+                searchString
+        );
+        assertEquals(1, matchedHeaders.size());
+        assertEquals(headerName, matchedHeaders.get(0).getName());
+        assertEquals(headerValue, matchedHeaders.get(0).getValue());
+
+    }
+
+    @Test
+    public void getHeadersWithHeaderNameNotMatchingPrefixCase() {
+
+        String headerValue = "34567as7dta8asd7";
+        String headerName = "x-account-meta-temp-url-key";
+        String searchString = "X-Account-Meta-";
+        final org.apache.http.Header myHeader = new BasicHeader(headerName, headerValue);
+
+        new Expectations() {{
+            response.getAllHeaders();
+            result = new org.apache.http.Header[]{myHeader};
+        }};
+        List<org.apache.http.Header> matchedHeaders = Header.getResponseHeadersStartingWith(
+                response,
+                searchString
+        );
+        assertEquals(1, matchedHeaders.size());
+        assertEquals(headerName, matchedHeaders.get(0).getName());
+        assertEquals(headerValue, matchedHeaders.get(0).getValue());
+    }
+
+    @Test
+    public void getHeadersWithNullPrefix() {
+
+        String searchString = null;
+        List<org.apache.http.Header> matchedHeaders = Header.getResponseHeadersStartingWith(
+                response,
+                searchString
+        );
+        assertEquals(0, matchedHeaders.size());
+    }
 }


### PR DESCRIPTION
Fixes #192
- Added case-insensitive check to getResponseHeadersStartingWith method
- Added validation for null prefix